### PR TITLE
Ensure bluetooth turn on and off properly along with ExposureNotification on Android

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ const App = () => {
       new I18nManager({
         locale,
         onError(error) {
-          console.log(error.message);
+          console.log('>>> i18N', error);
         },
       }),
     [locale],

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -14,7 +14,7 @@ export const getBackgroundI18n = async (forceLocale?: string) => {
       const i18nManager = new I18nManager({
         locale,
         onError(error) {
-          console.log(error.message);
+          console.log('>>> i18N', error);
         },
       });
       const translations = (locale: string) => LOCALES[locale];

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -12,7 +12,6 @@ const SystemStatusOff = ({i18n}: {i18n: I18n}) => {
   const startExposureNotificationService = useStartExposureNotificationService();
 
   const enableExposureNotifications = useCallback(() => {
-    console.log('ccccc enableExposureNotifications');
     startExposureNotificationService();
   }, [startExposureNotificationService]);
 


### PR DESCRIPTION
This PR ensures bluetooth turn on and off properly along with ExposureNotification on Android, including:
- Supports `BLUETOOTH_OFF` for `getStatus` same as iOS. 
- Check for bluetooth when turn on ExposureNotification. 

Fixes https://github.com/cds-snc/covid-shield-mobile/issues/95

### Context: 
Turn out on Android, when starting EN framework, it turns on bluetooth automatically without extra works / permission. Turning on bluetooth is usually be done by requesting `BLUETOOTH_ADMIN` permission in AndroidManifest. However, in order to do that, we need to stop EN service before calling start again.

### How to test?
- Run the app, complete onboarding flow, and turn on EN.
- Minimize the app. 
- Turn off bluetooth. 
- Resume the app. 
- Verify that the app is asking for turning on EN again and bluetooth is turned on after accepting permission.

### Outstanding
- iOS flow for bluetooth is different. Ex: 
  + Cannot turn on bluetooth programmatically. 
  + New UI needed to guide user to turn on bluetooth.
- Without minimizing the app, EN won't starts again because we only check for AppState, we need to use https://github.com/c19354837/react-native-system-setting to subscribe to bluetooth status update. 
- Need to polish `ExposureNotificationService.ts` to prevent UI flashing. 
=> Follow up PR is coming...

Fixes https://github.com/cds-snc/covid-shield-mobile/issues/95