### PR TITLE
Fixes for Bluetooth enable / EN enable flow

### DIFF
--- a/src/components/InfoBlock.tsx
+++ b/src/components/InfoBlock.tsx
@@ -17,6 +17,7 @@ export interface InfoBlockProps {
     text: string;
     action: () => void;
   };
+  showButton?: boolean;
 }
 
 export const InfoBlock = ({
@@ -27,6 +28,7 @@ export const InfoBlock = ({
   backgroundColor,
   title,
   titleBolded,
+  showButton,
 }: InfoBlockProps) => {
   return (
     <Box borderRadius={10} backgroundColor={backgroundColor} padding="m" alignItems="flex-start">
@@ -58,9 +60,15 @@ export const InfoBlock = ({
       <Text variant="bodyText" fontSize={16} color={color} marginBottom="m">
         {text}
       </Text>
-      <Box marginHorizontal="none" alignSelf="stretch">
-        <Button text={buttonText} onPress={action} variant="bigFlat" color={color} />
-      </Box>
+      {showButton ? (
+        <Box marginHorizontal="none" alignSelf="stretch">
+          <Button text={buttonText} onPress={action} variant="bigFlat" color={color} />
+        </Box>
+      ) : null}
     </Box>
   );
+};
+
+InfoBlock.defaultProps = {
+  showButton: true,
 };

--- a/src/screens/home/views/BluetoothDisabledView.tsx
+++ b/src/screens/home/views/BluetoothDisabledView.tsx
@@ -11,10 +11,10 @@ export const BluetoothDisabledView = () => {
       <Box marginBottom="l">
         <Icon name="icon-bluetooth-disabled" size={44} />
       </Box>
-      <Text textAlign="center" variant="bodyTitle" color="bodyText" marginBottom="l" accessibilityRole="header">
+      <Text variant="bodyTitle" color="bodyText" marginBottom="l" accessibilityRole="header">
         {i18n.translate('Home.BluetoothDisabled')}
       </Text>
-      <Text variant="bodyText" color="bodyText" textAlign="center">
+      <Text variant="bodyText" color="bodyText" marginBottom="l">
         {i18n.translate('Home.EnableBluetoothCTA')}
       </Text>
     </BaseHomeView>

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -2,18 +2,23 @@ import React, {useCallback} from 'react';
 import {useNavigation} from '@react-navigation/native';
 import {Box, InfoBlock, BoxProps} from 'components';
 import {useI18n, I18n} from '@shopify/react-i18n';
-import {SystemStatus, useStartExposureNotificationService} from 'services/ExposureNotificationService';
+import {SystemStatus} from 'services/ExposureNotificationService';
+import {Linking} from 'react-native';
 
 import {InfoShareView} from './InfoShareView';
 import {StatusHeaderView} from './StatusHeaderView';
 
 const SystemStatusOff = ({i18n}: {i18n: I18n}) => {
-  const startExposureNotificationService = useStartExposureNotificationService();
+  // const startExposureNotificationService = useStartExposureNotificationService();
 
-  const enableExposureNotifications = useCallback(() => {
-    console.log('ccccc enableExposureNotifications');
-    startExposureNotificationService();
-  }, [startExposureNotificationService]);
+  // const enableExposureNotifications = useCallback(() => {
+  //   console.log('ccccc enableExposureNotifications');
+  //   startExposureNotificationService();
+  // }, [startExposureNotificationService]);
+
+  const toSettings = useCallback(() => {
+    Linking.openSettings();
+  }, []);
 
   return (
     <InfoBlock
@@ -21,14 +26,13 @@ const SystemStatusOff = ({i18n}: {i18n: I18n}) => {
       title={i18n.translate('OverlayOpen.ExposureNotificationCardStatus')}
       titleBolded={i18n.translate('OverlayOpen.ExposureNotificationCardStatusOff')}
       text={i18n.translate('OverlayOpen.ExposureNotificationCardBody')}
-      button={{text: i18n.translate('OverlayOpen.ExposureNotificationCardAction'), action: enableExposureNotifications}}
+      button={{text: i18n.translate('OverlayOpen.ExposureNotificationCardAction'), action: toSettings}}
       backgroundColor="errorBackground"
       color="errorText"
     />
   );
 };
 
-/*
 const BluetoothStatusOff = ({i18n}: {i18n: I18n}) => {
   const toSettings = useCallback(() => {
     Linking.openSettings();
@@ -42,10 +46,10 @@ const BluetoothStatusOff = ({i18n}: {i18n: I18n}) => {
       button={{text: i18n.translate('OverlayOpen.BluetoothCardAction'), action: toSettings}}
       backgroundColor="errorBackground"
       color="errorText"
+      showButton={false}
     />
   );
 };
-*/
 
 const NotificationStatusOff = ({action, i18n}: {action: () => void; i18n: I18n}) => {
   return (
@@ -76,16 +80,16 @@ export const OverlayView = ({status, notificationWarning, turnNotificationsOn, m
       <Box marginBottom="l">
         <StatusHeaderView enabled={status === SystemStatus.Active} />
       </Box>
-      {status !== SystemStatus.Active && (
+      {(status === SystemStatus.Disabled || status === SystemStatus.Restricted) && (
         <Box marginBottom="m" marginHorizontal="m">
           <SystemStatusOff i18n={i18n} />
         </Box>
       )}
-      {/* {status !== SystemStatus.Active && (
+      {status === SystemStatus.BluetoothOff && (
         <Box marginBottom="m" marginHorizontal="m">
           <BluetoothStatusOff i18n={i18n} />
         </Box>
-      )}*/}
+      )}
       {notificationWarning && (
         <Box marginBottom="m" marginHorizontal="m">
           <NotificationStatusOff action={turnNotificationsOn} i18n={i18n} />


### PR DESCRIPTION
Closes #95

- Added bluetooth info block back in
- removed button on bluetooth info block since we cannot navigate to the right settings screen on ios
- fixed EN off button in info block
- fixed alignment on bluetooth off homescreen
- changed the display logic for the info blocks to make it consistent with the homescreen logic