### PR TITLE
Revert references to rollingStartNumber

### DIFF
--- a/src/bridge/ExposureNotification.ts
+++ b/src/bridge/ExposureNotification.ts
@@ -28,7 +28,7 @@ export enum Status {
 
 export interface TemporaryExposureKey {
   keyData: string;
-  rollingStartIntervalNumber: number;
+  rollingStartNumber: number;
   rollingPeriod: number;
   transmissionRiskLevel: RiskLevel;
 }

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -64,11 +64,13 @@ export class BackendService implements BackendInterface {
         covidshield.TemporaryExposureKey.create({
           keyData: Buffer.from(key.keyData, 'base64'),
           transmissionRiskLevel: key.transmissionRiskLevel,
-          rollingStartIntervalNumber: key.rollingStartIntervalNumber,
+          rollingStartIntervalNumber: key.rollingStartNumber,
           rollingPeriod: key.rollingPeriod,
         }),
       ),
     });
+    console.log(exposureKeys);
+    console.log(JSON.stringify(upload));
 
     const serializedUpload = covidshield.Upload.encode(upload).finish();
 

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -69,8 +69,6 @@ export class BackendService implements BackendInterface {
         }),
       ),
     });
-    console.log(exposureKeys);
-    console.log(JSON.stringify(upload));
 
     const serializedUpload = covidshield.Upload.encode(upload).finish();
 


### PR DESCRIPTION
An [upstream change](https://github.com/cds-snc/covid-shield-mobile/pull/87) changed a bunch of references from `rollingStartNumber` to `rollingStartIntervalNumber` to bring the references inline with the protobuf definition. 

Unfortunately, that broke things because the underlying framework provides the value as `rollingStartNumber`, so the payload being sent to the server was not setting the value and getting rejected. 

This reverts a few of those changes on the iOS side - will do android later.