### PR TITLE
Add local build lane

### DIFF
--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,5 +1,6 @@
 app_identifier "ca.tbs-sct.covid"
 apple_id ENV["APPLE_ID"]
+team_id ENV["TEAM_ID"]
 
 package_name "ca.canada.covid_notification"
 json_key_file "fastlane/certs/google-key.json"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,6 +24,27 @@ platform :ios do
     )
     upload_to_testflight
   end
+
+  lane :local do
+    get_certificates(
+      output_path: "fastlane/certs"
+    )
+    get_provisioning_profile(
+      output_path: "fastlane/certs"
+    )
+
+    build_app(
+      scheme: "CovidShield",
+      workspace: "./ios/CovidShield.xcworkspace",
+      export_method: "ad-hoc",
+      output_directory: "./build",
+      export_options: {
+        provisioningProfiles: {
+          "ca.tbs-sct.covid" => "ExposureNotification-ADHOC"
+        }
+      }
+    )
+  end
 end
 
 platform :android do

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -21,6 +21,11 @@ or alternatively using `brew cask install fastlane`
 fastlane ios beta
 ```
 
+### ios local
+```
+fastlane ios local
+```
+
 
 ----
 


### PR DESCRIPTION
Adds Fastlane config for a Local/Ad-Hoc build. To generate a build, run `bundle exec fastlane ios local` and you'll end up with a compiled .ipa file in `/build` folder.