### PR TITLE
Removed the big margin at top of the homepage

### DIFF
--- a/src/screens/home/components/BaseHomeView.tsx
+++ b/src/screens/home/components/BaseHomeView.tsx
@@ -13,7 +13,7 @@ export const BaseHomeView = ({children, iconName}: BaseHomeViewProps) => {
     <SafeAreaView>
       <Header />
       <ScrollView style={styles.flex} contentContainerStyle={[styles.scrollContainer]} bounces={false}>
-        <Box width="100%" justifyContent="flex-start" marginTop="xxl">
+        <Box width="100%" justifyContent="flex-start">
           <Box style={{...styles.primaryIcon}}>
             <Icon name={iconName} size={150} />
           </Box>


### PR DESCRIPTION
This brings the screens closer to the designs and displays more of the homescreen content that was below the fold.
<img width="391" alt="Screen Shot 2020-06-23 at 9 52 20 PM" src="https://user-images.githubusercontent.com/5498428/85497980-1b8d6b80-b59c-11ea-9048-b2da96154335.png">
<img width="393" alt="Screen Shot 2020-06-23 at 9 53 55 PM" src="https://user-images.githubusercontent.com/5498428/85497986-1defc580-b59c-11ea-9a47-84dbb3f60676.png">
