### PR TITLE
Changed the enable notifications button to work as before

### DIFF
--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -44,18 +44,14 @@ const BluetoothStatusOff = ({i18n}: {i18n: I18n}) => {
   );
 };
 
-const NotificationStatusOff = ({i18n}: {action: () => void; i18n: I18n}) => {
-  const toSettings = useCallback(() => {
-    Linking.openSettings();
-  }, []);
-
+const NotificationStatusOff = ({action, i18n}: {action: () => void; i18n: I18n}) => {
   return (
     <InfoButton
       title={i18n.translate('OverlayOpen.NotificationCardStatus')}
       color="mainBackground"
       internalLink
       text={i18n.translate('OverlayOpen.NotificationCardBody')}
-      onPress={toSettings}
+      onPress={action}
       variant="bigFlatNeutralGrey"
     />
   );


### PR DESCRIPTION
The button should take you to this dialogue, rather than the settings page:
<img width="391" alt="Screen Shot 2020-06-23 at 10 29 58 PM" src="https://user-images.githubusercontent.com/5498428/85500957-b0df2e80-b5a1-11ea-894e-492ac64bb476.png">
