### PR TITLE
Fixed margins on NoExposureCoveredRegionView

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -172,7 +172,7 @@ export const HomeScreen = () => {
   return (
     <NotificationPermissionStatusProvider>
       <Box flex={1} alignItems="center" backgroundColor={strToBackgroundColor(backgroundColor)}>
-        <Box flex={1} maxWidth={maxWidth} paddingTop="m">
+        <Box flex={1} maxWidth={maxWidth} paddingTop="m" alignSelf="stretch">
           <Content setBackgroundColor={setBackgroundColor} />
         </Box>
         <BottomSheetWrapper />

--- a/src/screens/home/components/BaseHomeView.tsx
+++ b/src/screens/home/components/BaseHomeView.tsx
@@ -10,9 +10,9 @@ interface BaseHomeViewProps {
 
 export const BaseHomeView = ({children, iconName}: BaseHomeViewProps) => {
   return (
-    <SafeAreaView>
+    <SafeAreaView style={styles.flex}>
       <Header />
-      <ScrollView style={styles.flex} contentContainerStyle={[styles.scrollContainer]} bounces={false}>
+      <ScrollView contentContainerStyle={[styles.scrollContainer]} bounces={false}>
         <Box width="100%" justifyContent="flex-start">
           <Box style={{...styles.primaryIcon}}>
             <Icon name={iconName} size={150} />


### PR DESCRIPTION
Fixed margins on larger screens (iPhone 11) with icons:

**OLD:**
![Simulator Screen Shot - iPhone 11 - 2020-06-25 at 14 40 46](https://user-images.githubusercontent.com/5861415/85782058-55718580-b6f4-11ea-86e8-49e89bb8ac7f.png)

**NEW:**
![Simulator Screen Shot - iPhone 11 - 2020-06-25 at 14 53 55](https://user-images.githubusercontent.com/5861415/85781920-34109980-b6f4-11ea-89bc-6b4397801c56.png)

