### PR TITLE
changed stroke width on chevron icons

### DIFF
--- a/src/assets/icon-chevron-white.svg
+++ b/src/assets/icon-chevron-white.svg
@@ -1,4 +1,4 @@
 <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 6L20 14L12 22" stroke="white" stroke-width="3"/>
+<path d="M12 6L20 14L12 22" stroke="white" stroke-width="2"/>
 </svg>
 

--- a/src/assets/icon-chevron.svg
+++ b/src/assets/icon-chevron.svg
@@ -1,4 +1,4 @@
 <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 6L20 14L12 22" stroke="black" stroke-width="3"/>
+<path d="M12 6L20 14L12 22" stroke="black" stroke-width="2"/>
 </svg>
 


### PR DESCRIPTION
Just noticed the strokes where dialed down from 3 to 2, updated the chevrons icon to better match the new external icon

before:
![Capture d’écran, le 2020-06-25 à 21 44 34](https://user-images.githubusercontent.com/5230720/85811914-507cf800-b72d-11ea-8bec-be1ecb61ba32.png)

after:
![Capture d’écran, le 2020-06-25 à 21 44 41](https://user-images.githubusercontent.com/5230720/85811912-4fe46180-b72d-11ea-8c60-bfce4997a486.png)