### PR TITLE
larger touch target for collapseContentHandleBar

### DIFF
--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -128,10 +128,10 @@ const styles = StyleSheet.create({
     top: -24,
   },
   collapseButton: {
-    height: 30,
-    width: 44,
+    height: 50,
+    width: '100%',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
   },
   spacer: {
     marginBottom: -18,


### PR DESCRIPTION
Increased the touch target when tapping to close the shield : collapseContentHandleBar is 50px high and 100% width. 