### PR TITLE
Upstream: Unzip downloaded keys ios

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -427,9 +427,8 @@ SPEC REPOS:
     - Flipper-RSocket
     - FlipperKit
     - OpenSSL-Universal
-    - YogaKit
-  trunk:
     - SSZipArchive
+    - YogaKit
 
 EXTERNAL SOURCES:
   DoubleConversion:
@@ -586,6 +585,6 @@ SPEC CHECKSUMS:
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: a9744d92f0988d5a39fa1a6c223f54fe5f92743d
+PODFILE CHECKSUM: e7cac3cd4b99490112af6bbd306430b7f57343ca
 
 COCOAPODS: 1.8.4

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -332,6 +332,14 @@ PODS:
     - React
   - RNSVG (12.1.0):
     - React
+  - RNZipArchive (5.0.2):
+    - React
+    - RNZipArchive/Core (= 5.0.2)
+    - SSZipArchive (= 2.2.2)
+  - RNZipArchive/Core (5.0.2):
+    - React
+    - SSZipArchive (= 2.2.2)
+  - SSZipArchive (2.2.2)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -403,10 +411,11 @@ DEPENDENCIES:
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNShare (from `../node_modules/react-native-share`)
   - RNSVG (from `../node_modules/react-native-svg`)
+  - RNZipArchive (from `../node_modules/react-native-zip-archive`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - boost-for-react-native
     - CocoaAsyncSocket
     - CocoaLibEvent
@@ -419,6 +428,8 @@ SPEC REPOS:
     - FlipperKit
     - OpenSSL-Universal
     - YogaKit
+  trunk:
+    - SSZipArchive
 
 EXTERNAL SOURCES:
   DoubleConversion:
@@ -509,6 +520,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-share"
   RNSVG:
     :path: "../node_modules/react-native-svg"
+  RNZipArchive:
+    :path: "../node_modules/react-native-zip-archive"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -568,9 +581,11 @@ SPEC CHECKSUMS:
   RNScreens: cf198f915f8a2bf163de94ca9f5bfc8d326c3706
   RNShare: fea1801315aa8875d6db73a4010b14afcd568765
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
+  RNZipArchive: ab51bc004a31657f34010254a9182014c6a81217
+  SSZipArchive: fa16b8cc4cdeceb698e5e5d9f67e9558532fbf23
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: e7cac3cd4b99490112af6bbd306430b7f57343ca
+PODFILE CHECKSUM: a9744d92f0988d5a39fa1a6c223f54fe5f92743d
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -415,7 +415,7 @@ DEPENDENCIES:
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - boost-for-react-native
     - CocoaAsyncSocket
     - CocoaLibEvent
@@ -587,4 +587,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: e7cac3cd4b99490112af6bbd306430b7f57343ca
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.7.5

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.1.0",
     "react-native-system-setting": "^1.7.4",
+    "react-native-zip-archive": "^5.0.2",
     "reanimated-bottom-sheet": "^1.0.0-alpha.20",
     "tweetnacl": "^1.0.3",
     "yarn": "^1.22.4"

--- a/src/bridge/ExposureNotification.ts
+++ b/src/bridge/ExposureNotification.ts
@@ -6,71 +6,15 @@
 
 import {NativeModules} from 'react-native';
 
-export enum RiskLevel {
-  Invalid = 0,
-  Lowest = 1,
-  Low = 2,
-  LowMedium = 3,
-  Medium = 4,
-  MediumHigh = 5,
-  High = 6,
-  VeryHigh = 7,
-  Highest = 8,
-}
+import ExposureNotificationAdapter from './ExposureNotificationAdapter';
 
-export enum Status {
-  Unknown = 'unknown',
-  Active = 'active',
-  Disabled = 'disabled',
-  BluetoothOff = 'bluetooth_off',
-  Restricted = 'restricted',
-}
-
-export interface TemporaryExposureKey {
-  keyData: string;
-  rollingStartNumber: number;
-  rollingPeriod: number;
-  transmissionRiskLevel: RiskLevel;
-}
-
-export interface ExposureSummary {
-  daysSinceLastExposure: number;
-  matchedKeyCount: number;
-  maximumRiskScore: number;
-}
-
-export interface ExposureConfiguration {
-  metadata?: object;
-  minimumRiskScore: number;
-  attenuationLevelValues: number[];
-  attenuationWeight: number;
-  daysSinceLastExposureLevelValues: number[];
-  daysSinceLastExposureWeight: number;
-  durationLevelValues: number[];
-  durationWeight: number;
-  transmissionRiskLevelValues: number[];
-  transmissionRiskWeight: number;
-}
-
-export interface ExposureInformation {
-  dateMillisSinceEpoch: number;
-  durationMinutes: number;
-  attenuationValue: number;
-  transmissionRiskLevel: RiskLevel;
-  totalRiskScore: number;
-}
-
-export interface ExposureNotification {
-  start(): Promise<void>;
-  stop(): Promise<void>;
-  resetAllData(): Promise<void>;
-
-  getStatus(): Promise<Status>;
-
-  getTemporaryExposureKeyHistory(): Promise<TemporaryExposureKey[]>;
-
-  detectExposure(configuration: ExposureConfiguration, diagnosisKeysURLs: string[]): Promise<ExposureSummary>;
-  getExposureInformation(summary: ExposureSummary): Promise<ExposureInformation[]>;
-}
-
-export default NativeModules.ExposureNotification as ExposureNotification;
+export {
+  RiskLevel,
+  Status,
+  TemporaryExposureKey,
+  ExposureSummary,
+  ExposureConfiguration,
+  ExposureInformation,
+  ExposureNotification,
+} from './ExposureNotificationAPI';
+export default ExposureNotificationAdapter(NativeModules.ExposureNotification);

--- a/src/bridge/ExposureNotificationAPI.ts
+++ b/src/bridge/ExposureNotificationAPI.ts
@@ -1,0 +1,71 @@
+export enum RiskLevel {
+  Invalid = 0,
+  Lowest = 1,
+  Low = 2,
+  LowMedium = 3,
+  Medium = 4,
+  MediumHigh = 5,
+  High = 6,
+  VeryHigh = 7,
+  Highest = 8,
+}
+
+export enum Status {
+  // .Undefined is made up status to indicate js client that status hasn't been received from EN framework
+  Undefined = 'undefined',
+  Unknown = 'unknown',
+  Active = 'active',
+  Disabled = 'disabled',
+  BluetoothOff = 'bluetooth_off',
+  Restricted = 'restricted',
+}
+
+export interface TemporaryExposureKey {
+  keyData: string;
+  rollingStartIntervalNumber: number;
+  rollingPeriod: number;
+  transmissionRiskLevel: RiskLevel;
+}
+
+export interface ExposureSummary {
+  daysSinceLastExposure: number;
+  matchedKeyCount: number;
+  maximumRiskScore: number;
+}
+
+export interface ExposureConfiguration {
+  metadata?: object;
+  minimumRiskScore: number;
+  attenuationLevelValues: number[];
+  attenuationWeight: number;
+  daysSinceLastExposureLevelValues: number[];
+  daysSinceLastExposureWeight: number;
+  durationLevelValues: number[];
+  durationWeight: number;
+  transmissionRiskLevelValues: number[];
+  transmissionRiskWeight: number;
+}
+
+export interface ExposureInformation {
+  dateMillisSinceEpoch: number;
+  durationMinutes: number;
+  attenuationValue: number;
+  transmissionRiskLevel: RiskLevel;
+  totalRiskScore: number;
+}
+
+export interface ExposureNotification {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  resetAllData(): Promise<void>;
+
+  getStatus(): Promise<Status>;
+
+  getTemporaryExposureKeyHistory(): Promise<TemporaryExposureKey[]>;
+
+  detectExposure(configuration: ExposureConfiguration, diagnosisKeysURLs: string[]): Promise<ExposureSummary>;
+  getExposureInformation(
+    summary: ExposureSummary,
+    userExplanation: string /* used only by iOS */,
+  ): Promise<ExposureInformation[]>;
+}

--- a/src/bridge/ExposureNotificationAPI.ts
+++ b/src/bridge/ExposureNotificationAPI.ts
@@ -22,7 +22,7 @@ export enum Status {
 
 export interface TemporaryExposureKey {
   keyData: string;
-  rollingStartIntervalNumber: number;
+  rollingStartNumber: number;
   rollingPeriod: number;
   transmissionRiskLevel: RiskLevel;
 }

--- a/src/bridge/ExposureNotificationAdapter.android.ts
+++ b/src/bridge/ExposureNotificationAdapter.android.ts
@@ -1,0 +1,13 @@
+import {ExposureNotification, ExposureSummary, ExposureInformation} from './ExposureNotificationAPI';
+
+export default function ExposureNotificationAdapter(exposureNotificationAPI: any): ExposureNotification {
+  return {
+    ...exposureNotificationAPI,
+    getExposureInformation: (
+      summary: ExposureSummary,
+      _: string /* ignored on android */,
+    ): Promise<ExposureInformation[]> => {
+      return exposureNotificationAPI.getExposureInformation(summary);
+    },
+  };
+}

--- a/src/bridge/ExposureNotificationAdapter.d.ts
+++ b/src/bridge/ExposureNotificationAdapter.d.ts
@@ -1,0 +1,5 @@
+import {ExposureNotification} from './ExposureNotificationAPI';
+
+declare function ExposureNotificationAdapter(exposureNotificationAPI: ExposureNotification): ExposureNotification;
+
+export default ExposureNotificationAdapter;

--- a/src/bridge/ExposureNotificationAdapter.ios.ts
+++ b/src/bridge/ExposureNotificationAdapter.ios.ts
@@ -1,0 +1,31 @@
+import {unzip} from 'react-native-zip-archive';
+
+import {ExposureNotification, ExposureConfiguration, ExposureSummary} from './ExposureNotificationAPI';
+
+export default function ExposureNotificationAdapter(
+  exposureNotificationAPI: ExposureNotification,
+): ExposureNotification {
+  return {
+    ...exposureNotificationAPI,
+    detectExposure: async (
+      configuration: ExposureConfiguration,
+      diagnosisKeysURLs: string[],
+    ): Promise<ExposureSummary> => {
+      if (diagnosisKeysURLs.length === 0) {
+        throw new Error('Attempt to call detectExposure with empty list if downloaded files');
+      }
+      const keysZipUrl = diagnosisKeysURLs[0];
+
+      const components = keysZipUrl.split('/');
+      components.pop();
+      components.push('keys-export');
+      const targetDir = components.join('/');
+
+      const unzippedLocation = await unzip(keysZipUrl, targetDir);
+      return exposureNotificationAPI.detectExposure(configuration, [
+        `${unzippedLocation}/export.bin`,
+        `${unzippedLocation}/export.sig`,
+      ]);
+    },
+  };
+}

--- a/src/bridge/ExposureNotificationAdapter.ios.ts
+++ b/src/bridge/ExposureNotificationAdapter.ios.ts
@@ -12,7 +12,7 @@ export default function ExposureNotificationAdapter(
       diagnosisKeysURLs: string[],
     ): Promise<ExposureSummary> => {
       if (diagnosisKeysURLs.length === 0) {
-        throw new Error('Attempt to call detectExposure with empty list if downloaded files');
+        throw new Error('Attempt to call detectExposure with empty list of downloaded files');
       }
       const keysZipUrl = diagnosisKeysURLs[0];
 

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -16,7 +16,7 @@ export const RETRIEVE_URL = Config.RETRIEVE_URL;
 
 export const HMAC_KEY = Config.HMAC_KEY;
 
-export const REGION = parseInt(Config.REGION, 10);
+export const REGION = parseInt(Config.REGION, 10) || 302;
 
 export const TEST_MODE = Config.TEST_MODE === 'true' || false;
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -187,11 +187,15 @@ export class ExposureNotificationService {
     const runningDate = new Date();
 
     const lastCheckPeriod = periodSinceEpoch(lastFetchDate || addDays(runningDate, -14), hoursPerPeriod);
-    let runningPeriod = periodSinceEpoch(runningDate, hoursPerPeriod);
+    let runningPeriod = periodSinceEpoch(runningDate, hoursPerPeriod) - 1;
 
     while (runningPeriod > lastCheckPeriod) {
-      yield await this.backendInterface.retrieveDiagnosisKeys(runningPeriod);
-      runningPeriod -= hoursPerPeriod;
+      try {
+        yield await this.backendInterface.retrieveDiagnosisKeys(runningPeriod);
+        // eslint-disable-next-line no-empty
+      } catch {}
+
+      runningPeriod -= 1;
     }
   }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -187,7 +187,7 @@ export class ExposureNotificationService {
     const runningDate = new Date();
 
     const lastCheckPeriod = periodSinceEpoch(lastFetchDate || addDays(runningDate, -14), hoursPerPeriod);
-    let runningPeriod = periodSinceEpoch(runningDate, hoursPerPeriod) - 1;
+    let runningPeriod = periodSinceEpoch(runningDate, hoursPerPeriod);
 
     while (runningPeriod > lastCheckPeriod) {
       try {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -1,4 +1,4 @@
-import {ExposureInformation, Status as SystemStatus} from 'bridge/ExposureNotificationAPI';
+import {Status as SystemStatus, ExposureSummary} from 'bridge/ExposureNotificationAPI';
 import ExposureNotification from 'bridge/ExposureNotification';
 import PushNotification from 'bridge/PushNotification';
 import {Observable} from 'shared/Observable';
@@ -29,7 +29,7 @@ export type ExposureStatus =
     }
   | {
       type: 'exposed';
-      exposures: ExposureInformation[];
+      summary: ExposureSummary;
       lastChecked?: string;
     }
   | {
@@ -257,8 +257,7 @@ export class ExposureNotificationService {
         const summary = await this.exposureNotification.detectExposure(exposureConfiguration, [keysFilesUrl]);
 
         if (summary.matchedKeyCount > 0) {
-          const exposures = await this.exposureNotification.getExposureInformation(summary, 'User explanation');
-          return finalize({type: 'exposed', exposures});
+          return finalize({type: 'exposed', summary});
         }
       } catch (err) {
         console.log({err});

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -192,8 +192,9 @@ export class ExposureNotificationService {
     while (runningPeriod > lastCheckPeriod) {
       try {
         yield await this.backendInterface.retrieveDiagnosisKeys(runningPeriod);
-        // eslint-disable-next-line no-empty
-      } catch {}
+      } catch (err) {
+        console.log('Error while downloading key file:', err);
+      }
 
       runningPeriod -= 1;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7245,6 +7245,11 @@ react-native-system-setting@^1.7.4:
   resolved "https://registry.yarnpkg.com/react-native-system-setting/-/react-native-system-setting-1.7.4.tgz#605fb21fe901e5d25f37b864326aaddde33e926b"
   integrity sha512-hS97zoYI/pffiKWBx15X2e8y4srm8q2uCp3aO+49P+Hu3HMNi4BgOvAG+J7KRHdoKEnIapRoVV67pLQsLqjQzw==
 
+react-native-zip-archive@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-zip-archive/-/react-native-zip-archive-5.0.2.tgz#cfa2aa8c97dd4ccb2dd8c99812ec7d9e20bf7549"
+  integrity sha512-s/dSQ+XDK1aPnZ2YH1abIAWLwfylU1WptnQ0HuPVO0tahQKGQpcEgj+UQXnzPnUFHwAlTfvV7PjVyZQukNvWjw==
+
 react-native@0.62.2:
   version "0.62.2"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.62.2.tgz#d831e11a3178705449142df19a70ac2ca16bad10"


### PR DESCRIPTION
Cherry-picked changes from [upstream](https://github.com/CovidShield/mobile/pull/157)

Adds an adapter around ExposureNotification bridge so that it adds additional platform-specific behaviour (and unzipping downloaded files is such a behaviour on iOS)