### PR TITLE
CODEOWNERS: CDS devs must review code changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# CDS developers must review all changes to ensure security of changes
+*   @cds-snc/exposure-notification-devs


### PR DESCRIPTION
As we have more folks contributing from other places, adding this precaution to make sure we ensure the safety of the code changes. This will enable us to source help more broadly and not compromise security.

After merged, CODEOWNERS reviews can be enforced via the protected branch settings.