### PR TITLE
Bump min sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion= "28.0.3"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 28
         targetSdkVersion = 28
 


### PR DESCRIPTION
Based on review findings 

> The minimum SDK should be updated to 23 (currently at 21)