### PR TITLE
Moved en popup so it appears on the last step of onboarding

### DIFF
--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -8,6 +8,7 @@ import Carousel, {CarouselStatic, Pagination} from 'react-native-snap-carousel';
 import {useMaxContentWidth} from 'shared/useMaxContentWidth';
 import {useStorage} from 'services/StorageService';
 import {RegionPickerScreen} from 'screens/regionPicker';
+import {useStartExposureNotificationService} from 'services/ExposureNotificationService';
 
 import {Start} from './views/Start';
 import {WhatItsNot} from './views/WhatItsNot';
@@ -33,7 +34,7 @@ export const OnboardingScreen = () => {
   const carouselRef = useRef(null);
   const navigation = useNavigation();
   const {region, setRegion, setOnboarded} = useStorage();
-
+  const startExposureNotificationService = useStartExposureNotificationService();
   const maxWidth = useMaxContentWidth();
 
   const renderItem = useCallback(
@@ -59,9 +60,13 @@ export const OnboardingScreen = () => {
 
         return;
       }
+      if (currentIndex === contentData.length - 2) {
+        // we want the EN permission dialogue to appear on the last step.
+        startExposureNotificationService();
+      }
       (carouselRef.current! as CarouselStatic<ViewKey>).snapToNext();
     }
-  }, [currentIndex, navigation, setOnboarded]);
+  }, [currentIndex, navigation, setOnboarded, startExposureNotificationService]);
 
   const prevItem = useCallback(() => {
     setRegion(undefined);


### PR DESCRIPTION
![onboarding](https://user-images.githubusercontent.com/5498428/86027830-6c62f100-b9ee-11ea-9944-0d8c0fa9257d.gif)
