### PR TITLE
Move gradle properties to environment

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -154,11 +154,11 @@ android {
     }
     signingConfigs {
         release {
-            if (project.hasProperty('STOPCOVID_UPLOAD_STORE_FILE')) {
-                storeFile file(STOPCOVID_UPLOAD_STORE_FILE)
-                storePassword STOPCOVID_UPLOAD_STORE_PASSWORD
-                keyAlias STOPCOVID_UPLOAD_KEY_ALIAS
-                keyPassword STOPCOVID_UPLOAD_KEY_PASSWORD
+            if (project.env.get('STOPCOVID_UPLOAD_STORE_FILE')) {
+                storeFile file(project.env.get('STOPCOVID_UPLOAD_STORE_FILE'))
+                storePassword project.env.get('STOPCOVID_UPLOAD_STORE_PASSWORD')
+                keyAlias project.env.get('STOPCOVID_UPLOAD_KEY_ALIAS')
+                keyPassword project.env.get('STOPCOVID_UPLOAD_KEY_PASSWORD')
             }
         }
     }


### PR DESCRIPTION
Following the react-native docs on [Publishing to Google Play](https://reactnative.dev/docs/signed-apk-android) you end up with some sensitive information in `gradle.properties`. 

This change enables loading those variables from the environment (.env file).