### PR TITLE
Automatically assign new build to test group

### DIFF
--- a/fastlane/.env.example
+++ b/fastlane/.env.example
@@ -5,7 +5,7 @@ TEAM_ID=TEAM_ID
 PROFILE="Distribution Profile Name"
 PROFILE_ADHOC="AdHoc Profile Name"
 PROFILE_DEV="Development Profile Name"
-TEST_GROUPS=["Team Name"]
+TEST_GROUPS=["Group Name"]
 
 # ANDROID
 APP_ID_ANDROID=ca.gc.hcsc.canada.stopcovid

--- a/fastlane/.env.example
+++ b/fastlane/.env.example
@@ -4,6 +4,8 @@ APPLE_ID=your@email.com
 TEAM_ID=TEAM_ID
 PROFILE="Distribution Profile Name"
 PROFILE_ADHOC="AdHoc Profile Name"
+PROFILE_DEV="Development Profile Name"
+TEST_GROUPS=["Team Name"]
 
 # ANDROID
 APP_ID_ANDROID=ca.gc.hcsc.canada.stopcovid

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,9 @@ platform :ios do
         }
       }
     )
-    upload_to_testflight
+    upload_to_testflight(
+      groups: ENV["TEST_GROUPS"]
+    )
   end
 
   lane :local do


### PR DESCRIPTION
This tells fastlane to automatically assign new TestFlight builds to the test group.