### PR TITLE
Reduced margin on expanded menu

### DIFF
--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -118,7 +118,7 @@ export const OverlayView = ({status, notificationWarning, turnNotificationsOn, m
 
   return (
     <Box maxWidth={maxWidth}>
-      <Box marginBottom="l">
+      <Box marginBottom="s">
         <StatusHeaderView enabled={status === SystemStatus.Active} />
       </Box>
       <Box marginBottom="m" marginTop="xxl" marginHorizontal="m">

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -121,7 +121,7 @@ export const OverlayView = ({status, notificationWarning, turnNotificationsOn, m
       <Box marginBottom="s">
         <StatusHeaderView enabled={status === SystemStatus.Active} />
       </Box>
-      <Box marginBottom="m" marginTop="xxl" marginHorizontal="m">
+      <Box marginBottom="m" marginTop="s" marginHorizontal="m">
         <ShareDiagnosisCode i18n={i18n} />
       </Box>
       {(status === SystemStatus.Disabled || status === SystemStatus.Restricted) && (


### PR DESCRIPTION
Fixes #322 
I removed the extra margins from the expanded menu.

The extra margins in the collapsed menu is by design, I can remove more margins if needed. 

