### PR TITLE
Onboarding accessibility

### DIFF
--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -37,16 +37,43 @@ export const OnboardingScreen = () => {
   const startExposureNotificationService = useStartExposureNotificationService();
   const maxWidth = useMaxContentWidth();
 
+  const isStart = currentIndex === 0;
+  const isEnd = currentIndex === contentData.length - 1;
+
+  let endText = 'EndSkip';
+  let endBtnStyle = '';
+
+  if (isEnd && region && region !== 'None') {
+    endText = 'End';
+    endBtnStyle = 'ready';
+  }
+
+  const [layout, setLayout] = useState<LayoutRectangle | undefined>();
+  const onLayout = useCallback(({nativeEvent: {layout}}: LayoutChangeEvent) => {
+    setLayout(layout);
+  }, []);
+
   const renderItem = useCallback(
     ({item}: {item: ViewKey}) => {
       const ItemComponent = viewComponents[item];
       return (
-        <Box maxWidth={maxWidth} alignSelf="center">
+        <Box maxWidth={maxWidth} alignSelf="center" style={isEnd ? styles.itemEnd : styles.item}>
           <ItemComponent />
+          <Box margin="m">
+            {isEnd ? (
+              <Button
+                text={i18n.translate(`Onboarding.Action${endText}`)}
+                variant={endBtnStyle === 'ready' ? 'thinFlat' : 'thinFlatNeutralGrey'}
+                onPress={nextItem}
+              />
+            ) : (
+              <Button text={i18n.translate('Onboarding.ActionNext')} variant="thinFlat" onPress={nextItem} />
+            )}
+          </Box>
         </Box>
       );
     },
-    [maxWidth],
+    [maxWidth, isEnd],
   );
 
   const nextItem = useCallback(async () => {
@@ -83,17 +110,6 @@ export const OnboardingScreen = () => {
     }
   }, []);
 
-  const isStart = currentIndex === 0;
-  const isEnd = currentIndex === contentData.length - 1;
-
-  let endText = 'EndSkip';
-  let endBtnStyle = '';
-
-  if (isEnd && region && region !== 'None') {
-    endText = 'End';
-    endBtnStyle = 'ready';
-  }
-
   const BackButton = (
     <Button
       backButton
@@ -103,11 +119,6 @@ export const OnboardingScreen = () => {
       onPress={prevItem}
     />
   );
-
-  const [layout, setLayout] = useState<LayoutRectangle | undefined>();
-  const onLayout = useCallback(({nativeEvent: {layout}}: LayoutChangeEvent) => {
-    setLayout(layout);
-  }, []);
 
   return (
     <Box flex={1} backgroundColor="overlayBackground">
@@ -154,26 +165,18 @@ export const OnboardingScreen = () => {
             </View>
           )}
         </Box>
-
-        <Box paddingHorizontal="m" alignItems="center" justifyContent="center" flexDirection="row" marginBottom="l">
-          <Box flex={1}>
-            {isEnd ? (
-              <Button
-                text={i18n.translate(`Onboarding.Action${endText}`)}
-                variant={endBtnStyle === 'ready' ? 'thinFlat' : 'thinFlatNeutralGrey'}
-                onPress={nextItem}
-              />
-            ) : (
-              <Button text={i18n.translate('Onboarding.ActionNext')} variant="thinFlat" onPress={nextItem} />
-            )}
-          </Box>
-        </Box>
       </SafeAreaView>
     </Box>
   );
 };
 
 const styles = StyleSheet.create({
+  item: {
+    marginBottom: 0,
+  },
+  itemEnd: {
+    marginBottom: 180,
+  },
   spacer: {
     marginBottom: 57,
   },

--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -73,7 +73,7 @@ export const OnboardingScreen = () => {
         </Box>
       );
     },
-    [maxWidth, isEnd],
+    [maxWidth, isEnd, region],
   );
 
   const nextItem = useCallback(async () => {

--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -72,23 +72,26 @@ export const OnboardingScreen = () => {
     (flatListRef.current! as FlatList<ViewKey>).scrollToIndex({index: currentIndex - 1});
   }, [currentIndex]);
 
-  const onViewableItemsChanged = useCallback(({viewableItems}) => {
-    if (viewableItems.length <= 0) {
-      return;
-    }
-    const index: number = viewableItems[0].index;
-    setCurrentIndex(index);
+  const onViewableItemsChanged = useCallback(
+    ({viewableItems}) => {
+      if (viewableItems.length <= 0) {
+        return;
+      }
+      const index: number = viewableItems[0].index;
+      setCurrentIndex(index);
 
-    // we want the EN permission dialogue to appear on the last step.
-    if (index === contentData.length - 1) {
-      startExposureNotificationService();
-    }
+      // we want the EN permission dialogue to appear on the last step.
+      if (index === contentData.length - 1) {
+        startExposureNotificationService();
+      }
 
-    // we want region cleared on the 2nd last step
-    if (index === contentData.length - 2) {
-      setRegion(undefined);
-    }
-  }, []);
+      // we want region cleared on the 2nd last step
+      if (index === contentData.length - 2) {
+        setRegion(undefined);
+      }
+    },
+    [setRegion, startExposureNotificationService],
+  );
 
   const renderItem = useCallback(
     ({item}: {item: ViewKey}) => {
@@ -130,7 +133,7 @@ export const OnboardingScreen = () => {
         </Box>
       );
     },
-    [currentIndex, windowWidth, maxWidth, isEnd, region, nextItem, endText],
+    [currentIndex, windowWidth, maxWidth, isEnd, region, nextItem, endText, endBtnStyle, i18n],
   );
 
   const BackButton = (

--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -146,7 +146,7 @@ export const OnboardingScreen = () => {
     />
   );
 
-  const VIEWABILITY_CONFIG = {
+  const viewabilityConfig = {
     minimumViewTime: 50,
     viewAreaCoveragePercentThreshold: 100,
   };

--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -176,7 +176,7 @@ export const OnboardingScreen = () => {
                 pagingEnabled
                 disableIntervalMomentum
                 onViewableItemsChanged={onViewableItemsChanged}
-                viewabilityConfig={VIEWABILITY_CONFIG}
+                viewabilityConfig={viewabilityConfig}
               />
             </View>
           )}

--- a/src/screens/regionPicker/RegionPicker.tsx
+++ b/src/screens/regionPicker/RegionPicker.tsx
@@ -13,39 +13,37 @@ export const RegionPickerScreen = () => {
 
   return (
     <Box style={regionStyles.flex} justifyContent="flex-start" backgroundColor="overlayBackground">
-      <SafeAreaView style={regionStyles.flex}>
-        <ScrollView style={regionStyles.flex}>
-          <Box flex={1} paddingHorizontal="m">
-            <Text marginBottom="s" variant="bodyTitle" color="overlayBodyText" accessibilityRole="header">
-              {i18n.translate('RegionPicker.Title')}
-            </Text>
-            <Text marginVertical="m" variant="bodyText" color="overlayBodyText">
-              {i18n.translate('RegionPicker.Body')}
-            </Text>
-            <Box
-              marginTop="s"
-              paddingHorizontal="m"
-              borderRadius={10}
-              backgroundColor="infoBlockNeutralBackground"
-              accessibilityRole="radiogroup"
-            >
-              {regionData.map(item => {
-                return (
-                  <RegionItem
-                    key={item.code}
-                    selected={region === item.code}
-                    onPress={async selectedRegion => {
-                      setRegion(selectedRegion);
-                    }}
-                    name={i18n.translate(`RegionPicker.${item.code}`)}
-                    {...item}
-                  />
-                );
-              })}
-            </Box>
+      <ScrollView style={regionStyles.flex}>
+        <Box flex={1} paddingHorizontal="m">
+          <Text marginBottom="s" variant="bodyTitle" color="overlayBodyText" accessibilityRole="header">
+            {i18n.translate('RegionPicker.Title')}
+          </Text>
+          <Text marginVertical="m" variant="bodyText" color="overlayBodyText">
+            {i18n.translate('RegionPicker.Body')}
+          </Text>
+          <Box
+            marginTop="s"
+            paddingHorizontal="m"
+            borderRadius={10}
+            backgroundColor="infoBlockNeutralBackground"
+            accessibilityRole="radiogroup"
+          >
+            {regionData.map(item => {
+              return (
+                <RegionItem
+                  key={item.code}
+                  selected={region === item.code}
+                  onPress={async selectedRegion => {
+                    setRegion(selectedRegion);
+                  }}
+                  name={i18n.translate(`RegionPicker.${item.code}`)}
+                  {...item}
+                />
+              );
+            })}
           </Box>
-        </ScrollView>
-      </SafeAreaView>
+        </Box>
+      </ScrollView>
     </Box>
   );
 };

--- a/src/screens/regionPicker/RegionPicker.tsx
+++ b/src/screens/regionPicker/RegionPicker.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {Box, Text} from 'components';
 import {ScrollView} from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context';
 import {useI18n} from '@shopify/react-i18n';
 import {useStorage} from 'services/StorageService';
 

--- a/src/screens/regionPicker/RegionPicker.tsx
+++ b/src/screens/regionPicker/RegionPicker.tsx
@@ -12,7 +12,7 @@ export const RegionPickerScreen = () => {
   const {region, setRegion} = useStorage();
 
   return (
-    <Box justifyContent="flex-start" backgroundColor="overlayBackground">
+    <Box style={regionStyles.flex} justifyContent="flex-start" backgroundColor="overlayBackground">
       <SafeAreaView style={regionStyles.flex}>
         <ScrollView style={regionStyles.flex}>
           <Box flex={1} paddingHorizontal="m">


### PR DESCRIPTION
Fixes the following issues: #304 #317 #337 

The onboarding screen is now accessible using a screen reader from end to end. Tested on Android using Talkback.

Changes:
- Switched off of `Carousel` component to `FlatList` (had many issues with performance and accessibility with the Carousel)
- Moved the pagination and next button to the `renderItem` callback so that screen readers will read them out
- Fixed screen readers getting stuck on steps that had `BulletPoint` components in them