### PR TITLE
Fix submission flow when diagnosisKeys is empty

### DIFF
--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -176,8 +176,9 @@ export class ExposureNotificationService {
     }
     const auth = JSON.parse(submissionKeysStr) as SubmissionKeySet;
     const diagnosisKeys = await this.exposureNotification.getTemporaryExposureKeyHistory();
-
-    await this.backendInterface.reportDiagnosisKeys(auth, diagnosisKeys);
+    if (diagnosisKeys.length > 0) {
+      await this.backendInterface.reportDiagnosisKeys(auth, diagnosisKeys);
+    }
     await this.recordKeySubmission();
   }
 


### PR DESCRIPTION
This PR fixes submission flow when diagnosisKeys is empty by skipping server upload. 

Verified by forcing `diagnosisKeys` to empty to reproduce.

Resolves https://github.com/cds-snc/covid-shield-mobile/issues/370