### PR TITLE
Removed last checked display from offline screen

### DIFF
--- a/src/screens/home/views/NetworkDisabledView.tsx
+++ b/src/screens/home/views/NetworkDisabledView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useI18n} from '@shopify/react-i18n';
-import {Box, Text, LastCheckedDisplay, Icon} from 'components';
+import {Box, Text, Icon} from 'components';
 
 import {BaseHomeView} from '../components/BaseHomeView';
 
@@ -17,7 +17,6 @@ export const NetworkDisabledView = () => {
       <Text variant="bodyText" color="bodyText" marginBottom="m">
         {i18n.translate('Home.NoConnectivityDetailed')}
       </Text>
-      <LastCheckedDisplay />
       <Box marginBottom="xxl" />
     </BaseHomeView>
   );


### PR DESCRIPTION
Closes #313 

Safe to remove since it is not on this screen in figma, and it makes no sense to have this on the offline screen.

<img width="355" alt="Screen Shot 2020-07-03 at 12 35 02 AM" src="https://user-images.githubusercontent.com/5498428/86439074-0cf23300-bcc5-11ea-8e2a-db6407e72d13.png">
