### PR TITLE
Remove Google Play metadata from fastlane

### DIFF
--- a/fastlane/metadata/android/en-CA/full_description.txt
+++ b/fastlane/metadata/android/en-CA/full_description.txt
@@ -1,1 +1,0 @@
-Test test test.

--- a/fastlane/metadata/android/en-CA/short_description.txt
+++ b/fastlane/metadata/android/en-CA/short_description.txt
@@ -1,1 +1,0 @@
-app shell in prep for entitlement request and testing

--- a/fastlane/metadata/android/en-CA/title.txt
+++ b/fastlane/metadata/android/en-CA/title.txt
@@ -1,1 +1,0 @@
-Covid Exposure Notification Test App 1


### PR DESCRIPTION
We accidentally overwrote some metadata that had been added to the Store Listing through the website. This just removes those metadata files from fastlane control for now. We can revisit this later.