### PR TITLE
Collapse BottomSheet after submission flow is finished

### DIFF
--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -23,31 +23,26 @@ export interface BottomSheetBahavior {
   collapse(): void;
 }
 
-const BottomSheet = (
+const BottomSheetInternal = (
   {content: ContentComponent, collapsed: CollapsedComponent, extraContent}: BottomSheetProps,
   ref: React.Ref<BottomSheetBahavior>,
 ) => {
   const bottomSheetPosition = useRef(new Animated.Value(1));
-
   const bottomSheetRef: React.Ref<BottomSheetRaw> = useRef(null);
-  useImperativeHandle(ref, () => ({
-    expand: () => {
-      bottomSheetRef.current?.snapTo(1);
-    },
-    collapse: () => {
-      bottomSheetRef.current?.snapTo(0);
-    },
-  }));
-
   const [isExpanded, setIsExpanded] = useState(false);
   const [i18n] = useI18n();
   const toggleExpanded = useCallback(() => {
-    if (isExpanded) {
-      bottomSheetRef.current?.snapTo(1);
-    } else {
-      bottomSheetRef.current?.snapTo(0);
-    }
-  }, [isExpanded]);
+    setIsExpanded(isExpanded => !isExpanded);
+  }, []);
+
+  useImperativeHandle(ref, () => ({
+    expand: () => {
+      setIsExpanded(true);
+    },
+    collapse: () => {
+      setIsExpanded(false);
+    },
+  }));
 
   const insets = useSafeArea();
   const renderHeader = useCallback(() => <Box height={insets.top} />, [insets.top]);
@@ -156,4 +151,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default forwardRef(BottomSheet);
+export const BottomSheet = forwardRef(BottomSheetInternal);

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useRef, useEffect, useMemo} from 'react';
+import React, {forwardRef, useState, useCallback, useRef, useEffect, useMemo, useImperativeHandle} from 'react';
 import {View, StyleSheet, TouchableOpacity, useWindowDimensions} from 'react-native';
 import Animated from 'react-native-reanimated';
 import {useSafeArea} from 'react-native-safe-area-context';
@@ -18,9 +18,27 @@ export interface BottomSheetProps {
   extraContent?: boolean;
 }
 
-const BottomSheet = ({content: ContentComponent, collapsed: CollapsedComponent, extraContent}: BottomSheetProps) => {
+export interface BottomSheetBahavior {
+  expand(): void;
+  collapse(): void;
+}
+
+const BottomSheet = (
+  {content: ContentComponent, collapsed: CollapsedComponent, extraContent}: BottomSheetProps,
+  ref: React.Ref<BottomSheetBahavior>,
+) => {
   const bottomSheetPosition = useRef(new Animated.Value(1));
+
   const bottomSheetRef: React.Ref<BottomSheetRaw> = useRef(null);
+  useImperativeHandle(ref, () => ({
+    expand: () => {
+      bottomSheetRef.current?.snapTo(1);
+    },
+    collapse: () => {
+      bottomSheetRef.current?.snapTo(0);
+    },
+  }));
+
   const [isExpanded, setIsExpanded] = useState(false);
   const [i18n] = useI18n();
   const toggleExpanded = useCallback(() => {
@@ -138,4 +156,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default BottomSheet;
+export default forwardRef(BottomSheet);

--- a/src/components/BottomSheet/index.ts
+++ b/src/components/BottomSheet/index.ts
@@ -1,3 +1,1 @@
-import BottomSheet from './BottomSheet';
-
-export default BottomSheet;
+export * from './BottomSheet';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,4 @@
-export {default as BottomSheet} from './BottomSheet';
+export * from './BottomSheet';
 export * from './Box';
 export * from './Button';
 export * from './InfoButton';

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,7 +1,7 @@
-import React, {useEffect, useState, useRef} from 'react';
+import React, {useEffect, useState, useRef, useLayoutEffect} from 'react';
 import {useNetInfo} from '@react-native-community/netinfo';
 import {DrawerActions, useNavigation} from '@react-navigation/native';
-import {BottomSheet, Box} from 'components';
+import {BottomSheet, BottomSheetBahavior, Box} from 'components';
 import {DevSettings} from 'react-native';
 import {
   SystemStatus,
@@ -13,6 +13,7 @@ import {useMaxContentWidth} from 'shared/useMaxContentWidth';
 import {Theme} from 'shared/theme';
 import {useStorage} from 'services/StorageService';
 import {getRegionCase} from 'shared/RegionLogic';
+import {usePrevious} from 'shared/usePrevious';
 
 import {useExposureNotificationSystemStatusAutomaticUpdater} from '../../services/ExposureNotificationService';
 import {RegionCase} from '../../shared/Region';
@@ -32,8 +33,6 @@ import {
   useNotificationPermissionStatus,
   NotificationPermissionStatusProvider,
 } from './components/NotificationPermissionStatus';
-import {BottomSheetBahavior} from 'components/BottomSheet/BottomSheet';
-import {usePrevious} from 'shared/usePrevious';
 
 type BackgroundColor = keyof Theme['colors'];
 
@@ -149,13 +148,15 @@ const BottomSheetWrapper = () => {
   const [notificationStatus] = useNotificationPermissionStatus();
   const showNotificationWarning = notificationStatus !== 'granted';
 
-  const [exposueStatus] = useExposureStatus();
-  const previousExposureStatus = usePrevious(exposueStatus);
-  useEffect(() => {
-    if (previousExposureStatus?.type === 'monitoring' && exposueStatus.type === 'diagnosed') {
+  const currentStatus = useExposureStatus()[0].type;
+  const previousStatus = usePrevious(currentStatus);
+
+  useLayoutEffect(() => {
+    console.log('eeeeeeeeeeeeeeeeee', currentStatus, previousStatus);
+    if (previousStatus === 'monitoring' && currentStatus === 'diagnosed') {
       bottomSheetRef.current?.collapse();
     }
-  }, [exposueStatus.type, previousExposureStatus]);
+  }, [currentStatus, previousStatus]);
 
   return (
     <BottomSheet

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -152,7 +152,6 @@ const BottomSheetWrapper = () => {
   const previousStatus = usePrevious(currentStatus);
 
   useLayoutEffect(() => {
-    console.log('eeeeeeeeeeeeeeeeee', currentStatus, previousStatus);
     if (previousStatus === 'monitoring' && currentStatus === 'diagnosed') {
       bottomSheetRef.current?.collapse();
     }

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useState, useRef} from 'react';
 import {useNetInfo} from '@react-native-community/netinfo';
 import {DrawerActions, useNavigation} from '@react-navigation/native';
 import {BottomSheet, Box} from 'components';
@@ -32,6 +32,8 @@ import {
   useNotificationPermissionStatus,
   NotificationPermissionStatusProvider,
 } from './components/NotificationPermissionStatus';
+import {BottomSheetBahavior} from 'components/BottomSheet/BottomSheet';
+import {usePrevious} from 'shared/usePrevious';
 
 type BackgroundColor = keyof Theme['colors'];
 
@@ -143,10 +145,25 @@ const BottomSheetContent = () => {
 };
 
 const BottomSheetWrapper = () => {
+  const bottomSheetRef = useRef<BottomSheetBahavior>(null);
   const [notificationStatus] = useNotificationPermissionStatus();
   const showNotificationWarning = notificationStatus !== 'granted';
+
+  const [exposueStatus] = useExposureStatus();
+  const previousExposureStatus = usePrevious(exposueStatus);
+  useEffect(() => {
+    if (previousExposureStatus?.type === 'monitoring' && exposueStatus.type === 'diagnosed') {
+      bottomSheetRef.current?.collapse();
+    }
+  }, [exposueStatus.type, previousExposureStatus]);
+
   return (
-    <BottomSheet content={BottomSheetContent} collapsed={CollapsedContent} extraContent={showNotificationWarning} />
+    <BottomSheet
+      ref={bottomSheetRef}
+      content={BottomSheetContent}
+      collapsed={CollapsedContent}
+      extraContent={showNotificationWarning}
+    />
   );
 };
 

--- a/src/shared/usePrevious.ts
+++ b/src/shared/usePrevious.ts
@@ -1,0 +1,9 @@
+import {useRef, useEffect} from 'react';
+
+export function usePrevious<T>(value: T): T | null {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    Object.assign(ref, {current: value});
+  }, [value]);
+  return ref.current;
+}


### PR DESCRIPTION
This PR collapses BottomSheet after submission flow is finished by: 
- Expose BottomSheet using forwardRef https://reactjs.org/docs/hooks-reference.html#useimperativehandle
- Compare previous and current ExposureStatus to determine if the BottomSheet needs to be collapsed. This is not a generic solution but it is simple and prevent nested access to children views. 

Resolves https://github.com/cds-snc/covid-shield-mobile/issues/76