### PR TITLE
Improved release changelog formatting

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,8 @@ lane :github do
       text: "Tag (ex: android-v19): "
     ),
     description: changelog_from_git_commits(
-      merge_commit_filtering: "only_include_merges"
+      merge_commit_filtering: "only_include_merges",
+      pretty: "- %b [%s]"
     ),
     commitish: "master",
   )


### PR DESCRIPTION
Improves formatting of the generated Release Changelog. Will look more like this:

```
- Collapse BottomSheet after submission flow is finished [Merge pull request #387 from cds-snc/issue/76/close-drawer-after-submitting-code]
- Removed duplicate SafeArea in RegionPicker [Merge pull request #385 from cds-snc/region-picker-safe-area-fix]
- Upstream 201 [Merge pull request #380 from cds-snc/upstream-201]
- No Code screen region based guidance for Ontario [Merge pull request #384 from cds-snc/no-code-updates]
- Fix launch_screen temporarily [Merge pull request #383 from cds-snc/hotfix/launch_screen]
- Update en.json [Merge pull request #379 from cds-snc/katewilhelm-patch-3]
- Upstream 199 [Merge pull request #377 from cds-snc/upstream-199]
```