### PR TITLE
Make the code input styling easier to see

### DIFF
--- a/src/components/CodeInput.tsx
+++ b/src/components/CodeInput.tsx
@@ -37,7 +37,7 @@ export const CodeInput = ({value, onChange, accessibilityLabel}: CodeInputProps)
               key={`input-${x}`}
               flex={1}
               marginHorizontal="xs"
-              borderBottomWidth={1.5}
+              borderBottomWidth={3}
               borderBottomColor={inputBorderColor(value, x)}
             >
               <Text variant="codeInput" color="overlayBodyText" textAlign="center" marginBottom="s">

--- a/src/shared/theme/default.ts
+++ b/src/shared/theme/default.ts
@@ -35,7 +35,7 @@ export const palette = {
   gray2: '#585858',
   link: '#2B4380',
   green2: '#C9E7DE',
-  cdsYellow: '#FFCC33',
+  greenCheck: '#33D1A1',
 };
 
 const theme = {
@@ -65,7 +65,7 @@ const theme = {
     errorBackground: palette.errorLight,
     errorText: palette.error,
     infoBlockBrightBackground: palette.lightBlue,
-    infoBlockBrightText: palette.cdsYellow,
+    infoBlockBrightText: palette.greenCheck,
     infoBlockNeutralBackground: palette.neutralGrey,
     infoBlockNeutralText: palette.bodyBlack,
     infoBlockBlackBackground: palette.bodyBlack,

--- a/src/shared/theme/default.ts
+++ b/src/shared/theme/default.ts
@@ -35,6 +35,7 @@ export const palette = {
   gray2: '#585858',
   link: '#2B4380',
   green2: '#C9E7DE',
+  cdsYellow: '#FFCC33',
 };
 
 const theme = {
@@ -64,7 +65,7 @@ const theme = {
     errorBackground: palette.errorLight,
     errorText: palette.error,
     infoBlockBrightBackground: palette.lightBlue,
-    infoBlockBrightText: palette.brandBlue,
+    infoBlockBrightText: palette.cdsYellow,
     infoBlockNeutralBackground: palette.neutralGrey,
     infoBlockNeutralText: palette.bodyBlack,
     infoBlockBlackBackground: palette.bodyBlack,


### PR DESCRIPTION
"Closes" #276
This styling was already there but it was invisible because the lines were too narrow and the blue being used was too dark. So I made it CDS yellow:

![code_input](https://user-images.githubusercontent.com/5498428/86540257-fdd7d480-bec0-11ea-92f0-394afea1ed54.gif)

It is not perfect because the yellow styling is applied before the input is actually in focus. We plan to revisit this later.