### PR TITLE
Add timeout to detect exposure bridge on Android

### DIFF
--- a/android/app/src/main/java/app/covidshield/extensions/TimerExtensions.kt
+++ b/android/app/src/main/java/app/covidshield/extensions/TimerExtensions.kt
@@ -1,0 +1,8 @@
+package app.covidshield.extensions
+
+import kotlinx.coroutines.delay
+
+suspend fun <T> withDelay(timeMillis: Long, block: () -> T): T {
+    delay(timeMillis)
+    return block()
+}

--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -30,9 +30,9 @@ import com.google.android.gms.nearby.exposurenotification.ExposureNotificationSt
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
-import kotlinx.coroutines.withTimeout
 import java.io.File
 import java.util.*
 import kotlin.coroutines.CoroutineContext
@@ -111,7 +111,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
 
             // Temporary setTimeout as the EN framework doesn't return summary if no keys are matched
             // Ref https://github.com/cds-snc/covid-shield-mobile/issues/453
-            withTimeout(DETECT_EXPOSURE_TIMEOUT) {
+            withDelay(DETECT_EXPOSURE_TIMEOUT) {
                 onReceive(token)
             }
 
@@ -129,6 +129,11 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
                 putString(SUMMARY_HIDDEN_KEY, token)
             })
         }
+    }
+
+    suspend fun <T> withDelay(timeMillis: Long, block: suspend CoroutineScope.() -> T): T {
+        delay(timeMillis)
+        return block()
     }
 
     @ReactMethod

--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -14,6 +14,7 @@ import app.covidshield.extensions.toInformation
 import app.covidshield.extensions.toSummary
 import app.covidshield.extensions.toWritableArray
 import app.covidshield.extensions.toWritableMap
+import app.covidshield.extensions.withDelay
 import app.covidshield.models.Configuration
 import app.covidshield.models.ExposureKey
 import app.covidshield.receiver.ExposureNotificationBroadcastReceiver
@@ -30,7 +31,6 @@ import com.google.android.gms.nearby.exposurenotification.ExposureNotificationSt
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import java.io.File
@@ -112,6 +112,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
             // Temporary setTimeout as the EN framework doesn't return summary if no keys are matched
             // Ref https://github.com/cds-snc/covid-shield-mobile/issues/453
             withDelay(DETECT_EXPOSURE_TIMEOUT) {
+                log("detectExposure timeout", mapOf("token" to token))
                 onReceive(token)
             }
 
@@ -129,11 +130,6 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
                 putString(SUMMARY_HIDDEN_KEY, token)
             })
         }
-    }
-
-    suspend fun <T> withDelay(timeMillis: Long, block: suspend CoroutineScope.() -> T): T {
-        delay(timeMillis)
-        return block()
     }
 
     @ReactMethod

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -254,7 +254,6 @@ export class ExposureNotificationService {
       return finalize();
     }
 
-    const keysFileUrls: string[] = [];
     const generator = this.keysSinceLastFetch(currentStatus.lastCheckedPeriod);
     let lastCheckedPeriod = currentStatus.lastCheckedPeriod;
     while (true) {
@@ -263,16 +262,15 @@ export class ExposureNotificationService {
       if (!value) continue;
       const {keysFileUrl, period} = value;
       lastCheckedPeriod = Math.max(lastCheckedPeriod || 0, period);
-      keysFileUrls.push(keysFileUrl);
-    }
 
-    try {
-      const summary = await this.exposureNotification.detectExposure(exposureConfiguration, keysFileUrls);
-      if (summary.matchedKeyCount > 0) {
-        return finalize({type: 'exposed', summary, lastCheckedPeriod});
+      try {
+        const summary = await this.exposureNotification.detectExposure(exposureConfiguration, [keysFileUrl]);
+        if (summary.matchedKeyCount > 0) {
+          return finalize({type: 'exposed', summary, lastCheckedPeriod});
+        }
+      } catch (error) {
+        console.log('>>> detectExposure', error);
       }
-    } catch (error) {
-      console.log('>>> detectExposure', error);
     }
 
     return finalize({lastCheckedPeriod});


### PR DESCRIPTION
This PR adds 20s timeout to detect exposure bridge on Android due to current limitation of the framework. A follow up PR is needed to remove the timeout when the framework has new updates. 

Ref https://github.com/cds-snc/covid-shield-mobile/issues/453

