### PR TITLE
More robust handling of the exposureConfiguration download.

### DIFF
--- a/src/services/ExposureNotificationService/DefaultExposureConfiguration.json
+++ b/src/services/ExposureNotificationService/DefaultExposureConfiguration.json
@@ -1,0 +1,47 @@
+{
+  "minimumRiskScore": 1,
+  "attenuationLevelValues": [
+    0,
+    0,
+    2,
+    2,
+    2,
+    2,
+    2,
+    2
+  ],
+  "attenuationWeight": 50,
+  "daysSinceLastExposureLevelValues": [
+    0,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1
+  ],
+  "daysSinceLastExposureWeight": 50,
+  "durationLevelValues": [
+    0,
+    0,
+    0,
+    0,
+    5,
+    5,
+    5,
+    5
+  ],
+  "durationWeight": 50,
+  "transmissionRiskLevelValues": [
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1
+  ],
+  "transmissionRiskWeight": 50
+}

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -7,7 +7,10 @@ import {Observable, MapObservable} from 'shared/Observable';
 
 import {BackendInterface, SubmissionKeySet} from '../BackendService';
 
+import defaultExposureConfiguration from './DefaultExposureConfiguration.json';
+
 const SUBMISSION_AUTH_KEYS = 'submissionAuthKeys';
+const EXPOSURE_CONFIGURATION = 'exposureConfiguration';
 
 const SECURE_OPTIONS = {
   sharedPreferencesName: 'covidShieldSharedPreferences',
@@ -183,6 +186,25 @@ export class ExposureNotificationService {
     await this.recordKeySubmission();
   }
 
+  /**
+   * If the exposureConfiguration is not available from the server for some reason,
+   * try and use a previously stored configuration, or use the default configuration bundled with the app.
+   */
+  async getAlternateExposureConfiguration() {
+    try {
+      const exposureConfigurationStr = await this.secureStorage.getItem(EXPOSURE_CONFIGURATION, SECURE_OPTIONS);
+      if (exposureConfigurationStr) {
+        console.warn('Using previously saved exposureConfiguration');
+        return JSON.parse(exposureConfigurationStr);
+      } else {
+        throw new Error('Unable to use saved exposureConfiguration');
+      }
+    } catch (error) {
+      console.warn('Using default exposureConfiguration.', error);
+      return defaultExposureConfiguration;
+    }
+  }
+
   private async recordKeySubmission() {
     const currentStatus = this.exposureStatus.get();
     if (currentStatus.type !== 'diagnosed') return;
@@ -230,7 +252,20 @@ export class ExposureNotificationService {
   }
 
   private async performExposureStatusUpdate(): Promise<void> {
-    const exposureConfiguration = await this.backendInterface.getExposureConfiguration();
+    let exposureConfiguration;
+    try {
+      exposureConfiguration = await this.backendInterface.getExposureConfiguration();
+      console.info('Using downloaded exposureConfiguration.');
+      const serialized = JSON.stringify(exposureConfiguration);
+      await this.secureStorage.setItem(EXPOSURE_CONFIGURATION, serialized, SECURE_OPTIONS);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        console.error('JSON Parsing error: Unable to parse downloaded exposureConfiguration.', error);
+      } else {
+        console.error('Netowrk error: Unable to download exposureConfiguration.', error);
+      }
+      exposureConfiguration = this.getAlternateExposureConfiguration();
+    }
 
     const finalize = async (status: Partial<ExposureStatus> = {}) => {
       const timestamp = new Date().getTime();

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -1,5 +1,9 @@
 import {Platform} from 'react-native';
-import ExposureNotification, {ExposureSummary, Status as SystemStatus} from 'bridge/ExposureNotification';
+import ExposureNotification, {
+  ExposureConfiguration,
+  ExposureSummary,
+  Status as SystemStatus,
+} from 'bridge/ExposureNotification';
 import PushNotification from 'bridge/PushNotification';
 import {addDays, daysBetween, periodSinceEpoch} from 'shared/date-fns';
 import {I18n} from '@shopify/react-i18n';
@@ -190,7 +194,7 @@ export class ExposureNotificationService {
    * If the exposureConfiguration is not available from the server for some reason,
    * try and use a previously stored configuration, or use the default configuration bundled with the app.
    */
-  async getAlternateExposureConfiguration() {
+  async getAlternateExposureConfiguration(): Promise<ExposureConfiguration> {
     try {
       const exposureConfigurationStr = await this.secureStorage.getItem(EXPOSURE_CONFIGURATION, SECURE_OPTIONS);
       if (exposureConfigurationStr) {
@@ -252,7 +256,7 @@ export class ExposureNotificationService {
   }
 
   private async performExposureStatusUpdate(): Promise<void> {
-    let exposureConfiguration;
+    let exposureConfiguration: ExposureConfiguration;
     try {
       exposureConfiguration = await this.backendInterface.getExposureConfiguration();
       console.info('Using downloaded exposureConfiguration.');
@@ -264,7 +268,7 @@ export class ExposureNotificationService {
       } else {
         console.error('Netowrk error: Unable to download exposureConfiguration.', error);
       }
-      exposureConfiguration = this.getAlternateExposureConfiguration();
+      exposureConfiguration = await this.getAlternateExposureConfiguration();
     }
 
     const finalize = async (status: Partial<ExposureStatus> = {}) => {


### PR DESCRIPTION
 If it can't be downloaded or can not be parsed as JSON, then the app will use either the previously saved configuration or a configuration JSON file that is included with the app.