### PR TITLE
Fix accessibility in BottomSheet

### DIFF
--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -1,48 +1,53 @@
-import React, {forwardRef, useState, useCallback, useRef, useEffect, useMemo, useImperativeHandle} from 'react';
-import {View, StyleSheet, TouchableOpacity, useWindowDimensions} from 'react-native';
+import React, {forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState} from 'react';
+import {StyleSheet, useWindowDimensions, View} from 'react-native';
 import Animated from 'react-native-reanimated';
 import {useSafeArea} from 'react-native-safe-area-context';
 import BottomSheetRaw from 'reanimated-bottom-sheet';
-import {useI18n} from '@shopify/react-i18n';
 
 import {Box} from '../Box';
-import {Icon} from '../Icon';
 
 import {SheetContentsContainer} from './SheetContentsContainer';
 
-const {abs, sub, pow} = Animated;
-
-export interface BottomSheetProps {
-  collapsed?: React.ComponentType;
-  content: React.ComponentType;
-  extraContent?: boolean;
-}
-
-export interface BottomSheetBahavior {
+export interface BottomSheetBehavior {
   expand(): void;
   collapse(): void;
+  refreshSnapPoints(extraContent: boolean): void;
+  callbackNode: Animated.Value<number>;
+  setOnStateChange(onStateChange: (isExpanded: boolean) => void): void;
+}
+
+export interface BottomSheetProps {
+  collapsedComponent: React.ComponentType<BottomSheetBehavior>;
+  expandedComponent: React.ComponentType<BottomSheetBehavior>;
 }
 
 const BottomSheetInternal = (
-  {content: ContentComponent, collapsed: CollapsedComponent, extraContent}: BottomSheetProps,
-  ref: React.Ref<BottomSheetBahavior>,
+  {expandedComponent: ExpandedComponent, collapsedComponent: CollapsedComponent}: BottomSheetProps,
+  ref: React.Ref<BottomSheetBehavior>,
 ) => {
   const bottomSheetPosition = useRef(new Animated.Value(1));
   const bottomSheetRef: React.Ref<BottomSheetRaw> = useRef(null);
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [i18n] = useI18n();
-  const toggleExpanded = useCallback(() => {
-    setIsExpanded(isExpanded => !isExpanded);
-  }, []);
 
-  useImperativeHandle(ref, () => ({
-    expand: () => {
-      setIsExpanded(true);
-    },
-    collapse: () => {
-      setIsExpanded(false);
-    },
-  }));
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [extraContent, setExtraContent] = useState(false);
+  const [onStateChange, setOnStateChange] = useState<(isExpanded: boolean) => void>();
+
+  const behavior = useMemo<BottomSheetBehavior>(
+    () => ({
+      expand: () => {
+        setIsExpanded(true);
+      },
+      collapse: () => {
+        setIsExpanded(false);
+      },
+      refreshSnapPoints: setExtraContent,
+      callbackNode: bottomSheetPosition.current,
+      setOnStateChange: callback => setOnStateChange(() => callback),
+    }),
+    [],
+  );
+  useImperativeHandle(ref, () => behavior, [behavior]);
+  useEffect(() => onStateChange?.(isExpanded), [isExpanded, onStateChange]);
 
   const insets = useSafeArea();
   const renderHeader = useCallback(() => <Box height={insets.top} />, [insets.top]);
@@ -58,53 +63,24 @@ const BottomSheetInternal = (
     bottomSheetRef.current?.snapTo(isExpanded ? 0 : 1);
   }, [width, isExpanded, snapPoints]);
 
-  const expandedContentWrapper = useMemo(
-    () => (
-      <Animated.View style={{opacity: abs(sub(bottomSheetPosition.current, 1))}}>
-        <View style={styles.content}>
-          <ContentComponent />
-        </View>
-
-        <View style={styles.collapseContentHandleBar}>
-          <TouchableOpacity
-            onPress={toggleExpanded}
-            style={styles.collapseButton}
-            accessibilityLabel={i18n.translate('BottomSheet.Collapse')}
-            accessibilityRole="button"
-          >
-            <Icon name="sheet-handle-bar-close" size={44} />
-          </TouchableOpacity>
-        </View>
-      </Animated.View>
-    ),
-    [i18n, toggleExpanded],
-  );
-  const collapsedContentWrapper = useMemo(
-    () => (
-      <Animated.View style={{...styles.collapseContent, opacity: pow(bottomSheetPosition.current, 2)}}>
-        <View style={styles.collapseContentHandleBar}>
-          <Icon name="sheet-handle-bar" size={44} />
-        </View>
-        {CollapsedComponent ? (
-          <View style={styles.content}>
-            <CollapsedComponent />
-          </View>
-        ) : null}
-      </Animated.View>
-    ),
-    [CollapsedComponent],
-  );
+  const expandedComponentWrapper = useMemo(() => <ExpandedComponent {...behavior} />, [behavior]);
+  const collapsedComponentWrapper = useMemo(() => <CollapsedComponent {...behavior} />, [behavior]);
 
   const renderContent = useCallback(() => {
     return (
-      <SheetContentsContainer isExpanded={isExpanded} toggleExpanded={toggleExpanded}>
+      <SheetContentsContainer>
         <>
-          {collapsedContentWrapper}
-          {expandedContentWrapper}
+          <View
+            accessibilityElementsHidden={isExpanded}
+            importantForAccessibility={isExpanded ? 'no-hide-descendants' : undefined}
+          >
+            {collapsedComponentWrapper}
+          </View>
+          <View pointerEvents={isExpanded ? undefined : 'none'}>{expandedComponentWrapper}</View>
         </>
       </SheetContentsContainer>
     );
-  }, [collapsedContentWrapper, expandedContentWrapper, isExpanded, toggleExpanded]);
+  }, [collapsedComponentWrapper, expandedComponentWrapper, isExpanded]);
 
   return (
     <>
@@ -127,25 +103,6 @@ const BottomSheetInternal = (
 };
 
 const styles = StyleSheet.create({
-  content: {
-    marginTop: 10,
-  },
-  collapseContent: {
-    position: 'absolute',
-    width: '100%',
-  },
-  collapseContentHandleBar: {
-    position: 'absolute',
-    width: '100%',
-    alignItems: 'center',
-    top: -24,
-  },
-  collapseButton: {
-    height: 50,
-    width: '100%',
-    alignItems: 'center',
-    justifyContent: 'flex-start',
-  },
   spacer: {
     marginBottom: -18,
   },

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -71,12 +71,20 @@ const BottomSheetInternal = (
       <SheetContentsContainer>
         <>
           <View
+            style={styles.collapseContent}
             accessibilityElementsHidden={isExpanded}
             importantForAccessibility={isExpanded ? 'no-hide-descendants' : undefined}
+            pointerEvents={isExpanded ? 'none' : undefined}
           >
             {collapsedComponentWrapper}
           </View>
-          <View pointerEvents={isExpanded ? undefined : 'none'}>{expandedComponentWrapper}</View>
+          <View
+            pointerEvents={isExpanded ? undefined : 'none'}
+            accessibilityElementsHidden={!isExpanded}
+            importantForAccessibility={isExpanded ? undefined : 'no-hide-descendants'}
+          >
+            {expandedComponentWrapper}
+          </View>
         </>
       </SheetContentsContainer>
     );
@@ -105,6 +113,10 @@ const BottomSheetInternal = (
 const styles = StyleSheet.create({
   spacer: {
     marginBottom: -18,
+  },
+  collapseContent: {
+    position: 'absolute',
+    width: '100%',
   },
 });
 

--- a/src/components/BottomSheet/SheetContentsContainer.tsx
+++ b/src/components/BottomSheet/SheetContentsContainer.tsx
@@ -1,37 +1,15 @@
 import React from 'react';
-import {useI18n} from '@shopify/react-i18n';
-import {TouchableHighlight} from 'react-native';
 
 import {Box} from '../Box';
-import {SystemStatus, useSystemStatus} from '../../services/ExposureNotificationService';
 
 interface ContentProps {
-  isExpanded: boolean;
-  toggleExpanded: () => void;
   children?: React.ReactElement;
 }
 
-export const SheetContentsContainer = ({children, isExpanded, toggleExpanded}: ContentProps) => {
-  const [i18n] = useI18n();
-  const [systemStatus] = useSystemStatus();
-  const content = (
+export const SheetContentsContainer = ({children}: ContentProps) => {
+  return (
     <Box backgroundColor="overlayBackground" minHeight="100%">
       <Box marginTop="l">{children}</Box>
     </Box>
-  );
-
-  return (
-    <TouchableHighlight
-      disabled={isExpanded}
-      onPress={toggleExpanded}
-      accessibilityRole="button"
-      accessibilityLabel={
-        systemStatus === SystemStatus.Active
-          ? i18n.translate('BottomSheet.OnStatus')
-          : i18n.translate('BottomSheet.OffStatus')
-      }
-    >
-      {content}
-    </TouchableHighlight>
   );
 };

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useEffect, useState, useRef, useLayoutEffect} from 'react';
 import {useNetInfo} from '@react-native-community/netinfo';
 import {DrawerActions, useNavigation} from '@react-navigation/native';
-import {BottomSheet, BottomSheetBahavior, Box} from 'components';
+import {BottomSheet, BottomSheetBehavior, Box} from 'components';
 import {DevSettings, Linking} from 'react-native';
 import {
   SystemStatus,
@@ -105,7 +105,7 @@ const Content = ({setBackgroundColor}: ContentProps) => {
   }
 };
 
-const CollapsedContent = () => {
+const CollapsedContent = (bottomSheetBehavior: BottomSheetBehavior) => {
   const [systemStatus] = useSystemStatus();
   const [notificationStatus, turnNotificationsOn] = useNotificationPermissionStatus();
   const showNotificationWarning = notificationStatus !== 'granted';
@@ -119,11 +119,12 @@ const CollapsedContent = () => {
       status={systemStatus}
       notificationWarning={showNotificationWarning}
       turnNotificationsOn={turnNotificationsOn}
+      bottomSheetBehavior={bottomSheetBehavior}
     />
   );
 };
 
-const BottomSheetContent = () => {
+const ExpandedContent = (bottomSheetBehavior: BottomSheetBehavior) => {
   const [systemStatus] = useSystemStatus();
   const [notificationStatus, turnNotificationsOn] = useNotificationPermissionStatus();
   const showNotificationWarning = notificationStatus !== 'granted';
@@ -142,30 +143,7 @@ const BottomSheetContent = () => {
       notificationWarning={showNotificationWarning}
       turnNotificationsOn={turnNotificationsOnFn}
       maxWidth={maxWidth}
-    />
-  );
-};
-
-const BottomSheetWrapper = () => {
-  const bottomSheetRef = useRef<BottomSheetBahavior>(null);
-  const [notificationStatus] = useNotificationPermissionStatus();
-  const showNotificationWarning = notificationStatus !== 'granted';
-
-  const currentStatus = useExposureStatus()[0].type;
-  const previousStatus = usePrevious(currentStatus);
-
-  useLayoutEffect(() => {
-    if (previousStatus === 'monitoring' && currentStatus === 'diagnosed') {
-      bottomSheetRef.current?.collapse();
-    }
-  }, [currentStatus, previousStatus]);
-
-  return (
-    <BottomSheet
-      ref={bottomSheetRef}
-      content={BottomSheetContent}
-      collapsed={CollapsedContent}
-      extraContent={showNotificationWarning}
+      bottomSheetBehavior={bottomSheetBehavior}
     />
   );
 };
@@ -195,13 +173,33 @@ export const HomeScreen = () => {
   const maxWidth = useMaxContentWidth();
   const [backgroundColor, setBackgroundColor] = useState<string>('mainBackground');
 
+  const bottomSheetRef = useRef<BottomSheetBehavior>(null);
+  const [isBottomSheetExpanded, setIsBottomSheetExpanded] = useState(false);
+  const currentStatus = useExposureStatus()[0].type;
+  const previousStatus = usePrevious(currentStatus);
+  useLayoutEffect(() => {
+    if (previousStatus === 'monitoring' && currentStatus === 'diagnosed') {
+      bottomSheetRef.current?.collapse();
+    }
+  }, [currentStatus, previousStatus]);
+  useLayoutEffect(() => {
+    bottomSheetRef.current?.setOnStateChange(setIsBottomSheetExpanded);
+  }, []);
+
   return (
     <NotificationPermissionStatusProvider>
       <Box flex={1} alignItems="center" backgroundColor={strToBackgroundColor(backgroundColor)}>
-        <Box flex={1} maxWidth={maxWidth} paddingTop="m" alignSelf="stretch">
+        <Box
+          flex={1}
+          maxWidth={maxWidth}
+          paddingTop="m"
+          alignSelf="stretch"
+          accessibilityElementsHidden={isBottomSheetExpanded}
+          importantForAccessibility={isBottomSheetExpanded ? 'no-hide-descendants' : undefined}
+        >
           <Content setBackgroundColor={setBackgroundColor} />
         </Box>
-        <BottomSheetWrapper />
+        <BottomSheet ref={bottomSheetRef} expandedComponent={ExpandedContent} collapsedComponent={CollapsedContent} />
       </Box>
     </NotificationPermissionStatusProvider>
   );

--- a/src/screens/home/views/CollapsedOverlayView.tsx
+++ b/src/screens/home/views/CollapsedOverlayView.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {TouchableHighlight, View, StyleSheet} from 'react-native';
+import {TouchableOpacity, View, StyleSheet} from 'react-native';
 import Animated, {pow} from 'react-native-reanimated';
 import {Box, Text, BottomSheetBehavior, Icon} from 'components';
 import {useI18n} from '@shopify/react-i18n';
@@ -22,12 +22,12 @@ export const CollapsedOverlayView = ({status, notificationWarning, bottomSheetBe
   }, [notificationWarning, bottomSheetBehavior]);
 
   return (
-    <TouchableHighlight onPress={bottomSheetBehavior.expand}>
-      <Animated.View style={{...styles.collapseContent, opacity: pow(bottomSheetBehavior.callbackNode, 2)}}>
-        <View style={styles.collapseContentHandleBar}>
-          <Icon name="sheet-handle-bar" size={36} />
-        </View>
+    <TouchableOpacity onPress={bottomSheetBehavior.expand}>
+      <Animated.View style={{opacity: pow(bottomSheetBehavior.callbackNode, 2)}}>
         <View style={styles.content}>
+          <View style={styles.collapseContentHandleBar}>
+            <Icon name="sheet-handle-bar" size={36} />
+          </View>
           <Box>
             <Box marginBottom="m">
               <StatusHeaderView enabled={status === SystemStatus.Active} />
@@ -63,17 +63,14 @@ export const CollapsedOverlayView = ({status, notificationWarning, bottomSheetBe
           </Box>
         </View>
       </Animated.View>
-    </TouchableHighlight>
+    </TouchableOpacity>
   );
 };
 
 const styles = StyleSheet.create({
   content: {
-    marginTop: 10,
-  },
-  collapseContent: {
-    position: 'absolute',
-    width: '100%',
+    paddingTop: 10,
+    paddingBottom: 10,
   },
   collapseContentHandleBar: {
     position: 'absolute',

--- a/src/screens/home/views/CollapsedOverlayView.tsx
+++ b/src/screens/home/views/CollapsedOverlayView.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import {Box, Text} from 'components';
+import React, {useEffect} from 'react';
+import {TouchableHighlight, View, StyleSheet} from 'react-native';
+import Animated, {pow} from 'react-native-reanimated';
+import {Box, Text, BottomSheetBehavior, Icon} from 'components';
 import {useI18n} from '@shopify/react-i18n';
 import {SystemStatus} from 'services/ExposureNotificationService';
 
@@ -8,44 +10,75 @@ import {StatusHeaderView} from './StatusHeaderView';
 interface Props {
   status: SystemStatus;
   notificationWarning: boolean;
-  turnNotificationsOn: () => void;
+  turnNotificationsOn(): void;
+  bottomSheetBehavior: BottomSheetBehavior;
 }
 
-export const CollapsedOverlayView = ({status, notificationWarning}: Props) => {
+export const CollapsedOverlayView = ({status, notificationWarning, bottomSheetBehavior}: Props) => {
   const [i18n] = useI18n();
+
+  useEffect(() => {
+    bottomSheetBehavior.refreshSnapPoints(notificationWarning);
+  }, [notificationWarning, bottomSheetBehavior]);
+
   return (
-    <Box>
-      <Box marginBottom="m">
-        <StatusHeaderView enabled={status === SystemStatus.Active} />
-      </Box>
-      {notificationWarning && (
-        <Box
-          backgroundColor="infoBlockNeutralBackground"
-          borderRadius={10}
-          padding="m"
-          flex={1}
-          marginBottom="xs"
-          marginHorizontal="m"
-          justifyContent="center"
-          flexDirection="row"
-        >
-          <Text variant="overlayTitle" color="overlayBodyText" accessibilityRole="header">
-            {i18n.translate('OverlayClosed.NotificationStatus')}
-          </Text>
-          <Text
-            variant="overlayTitle"
-            color="overlayBodyText"
-            fontFamily="Noto Sans"
-            fontWeight="bold"
-            accessibilityRole="header"
-          >
-            {i18n.translate('OverlayClosed.NotificationStatusOff')}
-          </Text>
-        </Box>
-      )}
-      <Text variant="smallText" color="bodyTextSubdued" textAlign="center">
-        {i18n.translate('OverlayClosed.TapPrompt')}
-      </Text>
-    </Box>
+    <TouchableHighlight onPress={bottomSheetBehavior.expand}>
+      <Animated.View style={{...styles.collapseContent, opacity: pow(bottomSheetBehavior.callbackNode, 2)}}>
+        <View style={styles.collapseContentHandleBar}>
+          <Icon name="sheet-handle-bar" size={36} />
+        </View>
+        <View style={styles.content}>
+          <Box>
+            <Box marginBottom="m">
+              <StatusHeaderView enabled={status === SystemStatus.Active} />
+            </Box>
+            {notificationWarning && (
+              <Box
+                backgroundColor="infoBlockNeutralBackground"
+                borderRadius={10}
+                padding="m"
+                flex={1}
+                marginBottom="xs"
+                marginHorizontal="m"
+                justifyContent="center"
+                flexDirection="row"
+              >
+                <Text variant="overlayTitle" color="overlayBodyText" accessibilityRole="header">
+                  {i18n.translate('OverlayClosed.NotificationStatus')}
+                </Text>
+                <Text
+                  variant="overlayTitle"
+                  color="overlayBodyText"
+                  fontFamily="Noto Sans"
+                  fontWeight="bold"
+                  accessibilityRole="header"
+                >
+                  {i18n.translate('OverlayClosed.NotificationStatusOff')}
+                </Text>
+              </Box>
+            )}
+            <Text variant="smallText" color="bodyTextSubdued" textAlign="center">
+              {i18n.translate('OverlayClosed.TapPrompt')}
+            </Text>
+          </Box>
+        </View>
+      </Animated.View>
+    </TouchableHighlight>
   );
 };
+
+const styles = StyleSheet.create({
+  content: {
+    marginTop: 10,
+  },
+  collapseContent: {
+    position: 'absolute',
+    width: '100%',
+  },
+  collapseContentHandleBar: {
+    position: 'absolute',
+    width: '100%',
+    alignItems: 'center',
+    top: -24,
+  },
+});

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -140,6 +140,9 @@ export const OverlayView = ({
     <Animated.View style={{opacity: abs(sub(bottomSheetBehavior.callbackNode, 1))}}>
       <View style={styles.content}>
         <Box maxWidth={maxWidth}>
+          <Box marginBottom="s">
+            <StatusHeaderView enabled={status === SystemStatus.Active} />
+          </Box>
           <View style={styles.collapseContentHandleBar}>
             <TouchableOpacity
               onPress={bottomSheetBehavior.collapse}
@@ -150,9 +153,6 @@ export const OverlayView = ({
               <Icon name="sheet-handle-bar-close" size={36} />
             </TouchableOpacity>
           </View>
-          <Box marginBottom="s">
-            <StatusHeaderView enabled={status === SystemStatus.Active} />
-          </Box>
           <Box marginBottom="m" marginTop="s" marginHorizontal="m">
             <ShareDiagnosisCode i18n={i18n} />
           </Box>
@@ -191,7 +191,7 @@ const styles = StyleSheet.create({
     top: -32,
   },
   collapseButton: {
-    height: 36,
+    height: 48,
     width: '100%',
     alignItems: 'center',
     justifyContent: 'flex-start',

--- a/src/screens/home/views/StatusHeaderView.tsx
+++ b/src/screens/home/views/StatusHeaderView.tsx
@@ -11,11 +11,13 @@ export const StatusHeaderView = ({enabled}: Props) => {
   return (
     <Box justifyContent="center" flexDirection="row" alignItems="flex-start" paddingHorizontal="m">
       <Box paddingTop="xs" flexDirection="row" flexWrap="wrap">
-        <Text variant="overlayTitle" lineHeight={19} color={color}>
-          {i18n.translate('OverlayClosed.SystemStatus')}
-        </Text>
-        <Text variant="overlayTitle" lineHeight={19} color={color} fontFamily="Noto Sans" fontWeight="bold">
-          {enabled ? i18n.translate('OverlayClosed.SystemStatusOn') : i18n.translate('OverlayClosed.SystemStatusOff')}
+        <Text>
+          <Text variant="overlayTitle" lineHeight={19} color={color}>
+            {i18n.translate('OverlayClosed.SystemStatus')}
+          </Text>
+          <Text variant="overlayTitle" lineHeight={19} color={color} fontFamily="Noto Sans" fontWeight="bold">
+            {enabled ? i18n.translate('OverlayClosed.SystemStatusOn') : i18n.translate('OverlayClosed.SystemStatusOff')}
+          </Text>
         </Text>
       </Box>
     </Box>


### PR DESCRIPTION
This PR fixes (hopefully all) accessibility issues related to BottomSheet and content underneath. 

To prevent content underneath being read, we need to use `accessibilityElementsHidden` (for iOS) or `importantForAccessibility` (for Android) when BottomSheet is expanded.  

Resolves https://github.com/cds-snc/covid-shield-mobile/issues/432

