### PR TITLE
Fix notification priority on Android

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/PushNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/PushNotificationModule.kt
@@ -21,7 +21,6 @@ import com.facebook.react.bridge.ReadableMap
 import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import java.util.*
 import kotlin.coroutines.CoroutineContext
 
 private const val CHANNEL_ID = "CovidShield"
@@ -78,7 +77,7 @@ class PushNotificationModule(context: ReactApplicationContext) : ReactContextBas
             .setSmallIcon(R.drawable.ic_notification_icon)
             .setContentTitle(config.title)
             .setContentText(config.body)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setPriority(config.priority)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
         notificationManager.notify(config.uuid.hashCode(), builder.build())
@@ -89,8 +88,11 @@ private class PushNotificationConfig(
     @SerializedName("uuid") private val _uuid: String?,
     @SerializedName("alertAction") val action: String?,
     @SerializedName("alertBody") val body: String?,
-    @SerializedName("alertTitle") val title: String?
+    @SerializedName("alertTitle") val title: String?,
+    @SerializedName("priority") val _priority: Int?
 ) {
 
     val uuid get() = _uuid ?: "app.covidshield.exposure-notification"
+
+    val priority get() = _priority ?: NotificationCompat.PRIORITY_MAX
 }


### PR DESCRIPTION
Note: I didn't see same issue on my end. User can change notification priority if they want (see screenshots below). I suspect because the app notification is shown as `NotificationCompat.PRIORITY_DEFAULT`. It will be up to OS / default settings on device to group notification. This PR changes it to `NotificationCompat.PRIORITY_MAX` which makes sense because this is COVID-19 notification. 

Ref https://github.com/cds-snc/covid-shield-mobile/issues/336