### PR TITLE
Fixed Android splash screen getting cut off on smaller devices

### DIFF
--- a/android/app/src/main/res/layout/launch_screen.xml
+++ b/android/app/src/main/res/layout/launch_screen.xml
@@ -10,7 +10,6 @@
     <ImageView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#EEEEEE"
         android:scaleType="fitCenter"
         android:src="@drawable/launch_screen" />
 </RelativeLayout>

--- a/android/app/src/main/res/layout/launch_screen.xml
+++ b/android/app/src/main/res/layout/launch_screen.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/white"
-    android:backgroundTint="#FFFFFF"
+    android:background="#EEEEEE"
     android:orientation="vertical">
 
     <ImageView

--- a/android/app/src/main/res/layout/launch_screen.xml
+++ b/android/app/src/main/res/layout/launch_screen.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/white"
+    android:backgroundTint="#FFFFFF"
     android:orientation="vertical">
+
     <ImageView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:scaleType="centerCrop"
+        android:layout_height="match_parent"
+        android:background="#EEEEEE"
+        android:scaleType="fitCenter"
         android:src="@drawable/launch_screen" />
 </RelativeLayout>


### PR DESCRIPTION
Tested on Nexus 4 simulator and Pixel 3 device

- [x] Splash screen works on all screen sizes
- [ ] If SVG is provided for the launch screen I could also replace the PNGs with just one SVG file

### Before:
![Screenshot_1594150852](https://user-images.githubusercontent.com/5861415/86834175-804ec880-c068-11ea-93f3-14b89bd0e170.png)

### After:
![Screenshot_1594150896](https://user-images.githubusercontent.com/5861415/86834177-82188c00-c068-11ea-8bf2-7486a363637c.png)

