### PR TITLE
Support bundle in debug for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -87,6 +87,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
         enableHermes: true,  // clean and rebuild if changing
+        bundleInDebug: System.getProperty("bundleInDebug")?.toBoolean() ?: false,
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
This PR supports bundle in debug for Android via system prop. 

## How to test?
- Run
```
cd ./android && ./gradlew assembleDebug -DbundleInDebug=true
```
- Install apk at `./app/build/outputs/apk/debug/app-debug.apk` to device. 
- Verify the app working with react js server.