### PR TITLE
Adding `cache-control` headers to fetch / blobFetch requests.

### DIFF
--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -15,6 +15,7 @@ import {covidshield} from './covidshield';
 import {BackendInterface, SubmissionKeySet} from './types';
 
 const MAX_UPLOAD_KEYS = 14;
+const FETCH_HEADERS = {headers: {'Cache-Control': 'no-cache, no-store, must-revalidate'}};
 
 export class BackendService implements BackendInterface {
   retrieveUrl: string;
@@ -43,7 +44,7 @@ export class BackendService implements BackendInterface {
 
   async getExposureConfiguration() {
     const region = this.region?.get();
-    return (await fetch(`${this.retrieveUrl}/exposure-configuration/${region}.json`)).json();
+    return (await fetch(`${this.retrieveUrl}/exposure-configuration/${region}.json`, FETCH_HEADERS)).json();
   }
 
   async claimOneTimeCode(oneTimeCode: string): Promise<SubmissionKeySet> {

--- a/src/shared/fetch.ts
+++ b/src/shared/fetch.ts
@@ -1,6 +1,7 @@
 export function blobFetch(uri: string, method: 'GET' | 'POST', body?: Uint8Array): Promise<ArrayBuffer> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
+    xhr.setRequestHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
     xhr.onload = function() {
       if (xhr.status >= 200 && xhr.status <= 299) {
         resolve(xhr.response);


### PR DESCRIPTION
Adding `cache-control` headers at the **react-native** side of things instead of trying to implement them separately in iOS and Android.

Adding {'Cache-Control', 'no-cache, no-store, must-revalidate'} to the request headers.