### PR TITLE
Handling the `reject` of getRandomBytes for both iOS and Android.

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/CovidShieldModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/CovidShieldModule.kt
@@ -28,9 +28,13 @@ class CovidShieldModule(context: ReactApplicationContext) : ReactContextBaseJava
     @ReactMethod
     fun getRandomBytes(size: Int, promise: Promise) {
         promise.launch(this) {
-            val bytes = SecureRandom().generateSeed(size)
-            val base64Encoded = Base64.encodeToString(bytes, Base64.DEFAULT)
-            promise.resolve(base64Encoded)
+            try {
+                val bytes = SecureRandom().generateSeed(size)
+                val base64Encoded = Base64.encodeToString(bytes, Base64.DEFAULT)
+                promise.resolve(base64Encoded)
+            } catch (exception: Exception) {
+                promise.reject(exception);
+            }
         }
     }
 

--- a/ios/CovidShield/CovidShield.m
+++ b/ios/CovidShield/CovidShield.m
@@ -15,11 +15,14 @@ RCT_REMAP_METHOD(getRandomBytes, randomBytesWithSize:(NSUInteger)size withResolv
 {
   void *buff = malloc(size);
   int status = SecRandomCopyBytes(kSecRandomDefault, size, buff);
-  if (status == 0) {
+  free(buff);
+  if (status == errSecSuccess) {
     NSString *base64encoded = [[[NSData alloc] initWithBytes:buff length:size] base64EncodedStringWithOptions:0];
     resolve(base64encoded);
+  } else {
+    NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:status userInfo:nil];
+    reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription ,error);
   }
-  free(buff);
 }
 
 RCT_REMAP_METHOD(downloadDiagnosisKeysFile, downloadDiagnosisKeysFileWithURL:(NSString *)url WithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -47,7 +47,13 @@ export class BackendService implements BackendInterface {
   }
 
   async claimOneTimeCode(oneTimeCode: string): Promise<SubmissionKeySet> {
-    const randomBytes = await getRandomBytes(32);
+    let randomBytes: Buffer;
+    try {
+      randomBytes = await getRandomBytes(32);
+    } catch (error) {
+      console.error('getRandomBytes()', error);
+      throw new Error(error);
+    }
     nacl.setPRNG(buff => {
       buff.set(randomBytes, 0);
     });
@@ -96,7 +102,13 @@ export class BackendService implements BackendInterface {
     const serverPublicKey = Buffer.from(keyPair.serverPublicKey, 'base64');
     const clientPublicKey = Buffer.from(keyPair.clientPublicKey, 'base64');
 
-    const nonce = await getRandomBytes(24);
+    let nonce: Buffer;
+    try {
+      nonce = await getRandomBytes(24);
+    } catch (error) {
+      console.error('getRandomBytes()', error);
+      throw new Error(error);
+    }
     const encryptedPayload = nacl.box(serializedUpload, nonce, serverPublicKey, clientPrivate);
 
     await this.upload(encryptedPayload, nonce, serverPublicKey, clientPublicKey);


### PR DESCRIPTION
In both of the cases where getRandomBytes is called, if an error occurs, it will be logged so we know it happened, and thrown again and caught by the error handlers of FormView and ConsentView.