### PR TITLE
Update NSAppTransportSecurity values.

### DIFF
--- a/ios/CovidShield/Info.plist
+++ b/ios/CovidShield/Info.plist
@@ -35,16 +35,10 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
+		<key>NSAllowsLocalNetworking</key>
 		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
 	</dict>
 	<key>UIAppFonts</key>
 	<array>


### PR DESCRIPTION
This updates the iOS NSAppTransportSecurity values for better security between client and server.

While the ** NSAllowsLocalNetworking** key shouldn't be necessary, I have found that the simulator doesn't connect to the React-Native Metro server without that key.
