### PR TITLE
Improve detect exposure flow

### DIFF
--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
@@ -1,13 +1,27 @@
-import {ExposureNotification, ExposureSummary, ExposureInformation} from './types';
+import {ExposureNotification} from './types';
 
 export default function ExposureNotificationAdapter(exposureNotificationAPI: any): ExposureNotification {
   return {
     ...exposureNotificationAPI,
-    getExposureInformation: (
-      summary: ExposureSummary,
-      _: string /* ignored on android */,
-    ): Promise<ExposureInformation[]> => {
+    getExposureInformation: summary => {
       return exposureNotificationAPI.getExposureInformation(summary);
+    },
+    detectExposure: async (configuration, diagnosisKeysURLs) => {
+      return new Promise((resolve, reject) => {
+        if (diagnosisKeysURLs.length === 0) {
+          reject(new Error('Attempt to call detectExposure with empty list of downloaded files'));
+          return;
+        }
+        for (const diagnosisKeysURL of diagnosisKeysURLs) {
+          (async (diagnosisKeysURL: string) => {
+            const summary = await exposureNotificationAPI.detectExposure(configuration, [diagnosisKeysURL]);
+            // first detected exposure is enough
+            if (summary.matchedKeyCount > 0) {
+              resolve(summary);
+            }
+          })(diagnosisKeysURL);
+        }
+      });
     },
   };
 }

--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
@@ -1,16 +1,13 @@
 import {unzip} from 'react-native-zip-archive';
 
-import {ExposureNotification, ExposureConfiguration, ExposureSummary} from './types';
+import {ExposureNotification, ExposureSummary} from './types';
 
 export default function ExposureNotificationAdapter(
   exposureNotificationAPI: ExposureNotification,
 ): ExposureNotification {
   return {
     ...exposureNotificationAPI,
-    detectExposure: async (
-      configuration: ExposureConfiguration,
-      diagnosisKeysURLs: string[],
-    ): Promise<ExposureSummary> => {
+    detectExposure: async (configuration, diagnosisKeysURLs) => {
       if (diagnosisKeysURLs.length === 0) {
         throw new Error('Attempt to call detectExposure with empty list of downloaded files');
       }


### PR DESCRIPTION
Using timeout can introduce race condition. This PR change the implementation on Android by:
- Create a Promise wrapper to feed all 14 keys to the framework.
- If one of the request is returned with matched key count, the Promise will be resolved. 
- We still keep the logic of `Not persisting lastCheckPeriod` for Android only. So that we won't miss any cases.

Follow up of https://github.com/cds-snc/covid-shield-mobile/issues/453