### PR TITLE
fixing arrow alignment on infoshareitem

### DIFF
--- a/src/screens/home/views/InfoShareView.tsx
+++ b/src/screens/home/views/InfoShareView.tsx
@@ -23,9 +23,12 @@ const InfoShareItem = ({onPress, text, icon, lastItem, ...touchableProps}: InfoS
         backgroundColor="infoBlockNeutralBackground"
         borderRadius={5}
       >
-        <Text variant="bodyText" marginVertical="s" color="overlayBodyText">
-          {text}
-        </Text>
+        <Box flex={1}>
+          <Text variant="bodyText" marginVertical="s" color="overlayBodyText">
+            {text}
+          </Text>
+        </Box>
+
         <Box alignSelf="center">
           <Icon size={25} name={icon} />
         </Box>


### PR DESCRIPTION
Just noticed `infoshareitem` elements with longer text would nudge the arrow out of line. Wrapping text within a box and playing with its flex values fixes this. 

Before:
![Capture d’écran, le 2020-07-09 à 09 41 40](https://user-images.githubusercontent.com/5230720/87048528-d1c29900-c1c9-11ea-8516-1382e5a1e4a4.png)

After:
![Capture d’écran, le 2020-07-09 à 09 46 12](https://user-images.githubusercontent.com/5230720/87048531-d25b2f80-c1c9-11ea-9fc9-dff9196bdac9.png)
