### PR TITLE
Attempt to fix push notification

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ BackgroundScheduler.registerAndroidHeadlessPeriodicTask(async () => {
     SecureStorage,
     ExposureNotification,
   );
-  await exposureNotificationService.init();
   await exposureNotificationService.updateExposureStatusInBackground();
 });
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -42,6 +42,7 @@ export type ExposureStatus =
   | {
       type: 'exposed';
       summary: ExposureSummary;
+      notificationSent?: boolean;
       lastChecked?: {
         period: number;
         timestamp: number;
@@ -141,13 +142,15 @@ export class ExposureNotificationService {
 
   async updateExposureStatusInBackground() {
     await this.init();
-    const lastStatus = this.exposureStatus.get();
     await this.updateExposureStatus();
     const currentStatus = this.exposureStatus.get();
-    if (lastStatus.type === 'monitoring' && currentStatus.type === 'exposed') {
+    if (currentStatus.type === 'exposed' && !currentStatus.notificationSent) {
       PushNotification.presentLocalNotification({
         alertTitle: this.i18n.translate('Notification.ExposedMessageTitle'),
         alertBody: this.i18n.translate('Notification.ExposedMessageBody'),
+      });
+      await this.exposureStatus.append({
+        notificationSent: true,
       });
     }
     if (currentStatus.type === 'diagnosed' && currentStatus.needsSubmission) {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -113,11 +113,6 @@ export class ExposureNotificationService {
     });
   }
 
-  async init() {
-    const exposureStatus = JSON.parse((await this.storage.getItem(EXPOSURE_STATUS)) || 'null');
-    this.exposureStatus.append({...exposureStatus});
-  }
-
   async start(): Promise<void> {
     if (this.starting) {
       return;
@@ -145,6 +140,7 @@ export class ExposureNotificationService {
   }
 
   async updateExposureStatusInBackground() {
+    await this.init();
     const lastStatus = this.exposureStatus.get();
     await this.updateExposureStatus();
     const currentStatus = this.exposureStatus.get();
@@ -196,6 +192,11 @@ export class ExposureNotificationService {
       await this.backendInterface.reportDiagnosisKeys(auth, diagnosisKeys);
     }
     await this.recordKeySubmission();
+  }
+
+  private async init() {
+    const exposureStatus = JSON.parse((await this.storage.getItem(EXPOSURE_STATUS)) || 'null');
+    this.exposureStatus.append({...exposureStatus});
   }
 
   /**
@@ -337,7 +338,9 @@ export class ExposureNotificationService {
     }
 
     try {
+      console.log('eeeeeeeeee keysFileUrls', keysFileUrls);
       const summary = await this.exposureNotification.detectExposure(exposureConfiguration, keysFileUrls);
+      console.log('eeeeeeeeee summary', summary);
       if (summary.matchedKeyCount > 0) {
         return finalize(
           {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -341,9 +341,7 @@ export class ExposureNotificationService {
     }
 
     try {
-      console.log('eeeeeeeeee keysFileUrls', keysFileUrls);
       const summary = await this.exposureNotification.detectExposure(exposureConfiguration, keysFileUrls);
-      console.log('eeeeeeeeee summary', summary);
       if (summary.matchedKeyCount > 0) {
         return finalize(
           {

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -49,8 +49,8 @@ export const ExposureNotificationServiceProvider = ({
   );
 
   useEffect(() => {
-    backgroundScheduler.registerPeriodicTask(() => {
-      return exposureNotificationService.updateExposureStatusInBackground();
+    backgroundScheduler.registerPeriodicTask(async () => {
+      await exposureNotificationService.updateExposureStatusInBackground();
     });
   }, [backgroundScheduler, exposureNotificationService]);
 


### PR DESCRIPTION
This PR attempts to fix push notification. 

## What could when wrong on master?
### Initial state is incorrect:
Since we start persisting exposure status, we split `start` into `start` and `init`. Because the initial state is retrieved from local storage, it is async. So, if the app is running in background (through background job), master just call `updateExposureStatusInBackground` without calling init. Based on this assumption, 

1. On Android: ✅  
We call `init` before calling `updateExposureStatusInBackground` which means Android should receive notification. If there is no notification, it could be different issue.

2. On iOS: ❌ 
We don't call `init` in `backgroundScheduler.registerPeriodicTask` which means in some race condition, iOS won't have correct initial state. 

### Logic to show notification:
Also the logic for showing exposed notification is quite fragile to break https://github.com/cds-snc/covid-shield-mobile/blob/master/src/services/ExposureNotificationService/ExposureNotificationService.ts#L151. Essentially, we want to send exposure notification to user only once but the way we are doing it is checking the status from `monitoring` to `exposed`. 

This will break when: If user finishes onboarding and minimize the app, the app still runs in but without `updateExposureStatusInBackground`. It means if the status is changed to `exposed`, the next time `updateExposureStatusInBackground` is run, it won't show notification. In this case, user doesn't know that the app is set to exposed already. 


Ref https://github.com/cds-snc/covid-shield-mobile/issues/570