### PR TITLE
Announce deselected radio buttons in region picker

### DIFF
--- a/src/screens/regionPicker/RegionPickerShared.tsx
+++ b/src/screens/regionPicker/RegionPickerShared.tsx
@@ -43,7 +43,12 @@ export const regionData: Omit<RegionItemProps, 'onPress' | 'selected' | 'name'>[
 
 const RegionItem_ = ({code, onPress, name, lastItem, selected}: RegionItemProps) => (
   <>
-    <TouchableOpacity onPress={() => onPress(code)} accessibilityRole="radio" accessibilityState={{selected}}>
+    <TouchableOpacity
+      onPress={() => onPress(code)}
+      accessibilityRole="radio"
+      accessibilityState={{selected}}
+      accessibilityHint={selected ? name : `deselected ${name}`}
+    >
       <Box
         paddingVertical="m"
         marginHorizontal="-m"


### PR DESCRIPTION
When deselecting a radio button in the region picker the screen reader should now announce that it is no longer selected

Fixes #571 