### PR TITLE
Set region for downloading to 'CA'.

### DIFF
--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -42,8 +42,12 @@ export class BackendService implements BackendInterface {
   }
 
   async getExposureConfiguration() {
-    const region = this.region?.get();
-    return (await fetch(`${this.retrieveUrl}/exposure-configuration/${region}.json`)).json();
+    // purposely setting 'region' to the default value of `CA` regardless of what the user selected.
+    // this is only for the purpose of downloading the configuration file.
+    const region = 'CA';
+    const exposureConfigurationUrl = `${this.retrieveUrl}/exposure-configuration/${region}.json`;
+    console.info(`Exposure Configuration URL: ${exposureConfigurationUrl}`);
+    return (await fetch(exposureConfigurationUrl)).json();
   }
 
   async claimOneTimeCode(oneTimeCode: string): Promise<SubmissionKeySet> {


### PR DESCRIPTION
This forces the downloaded configuration to be the default 'CA' configuration. This is independent of what the user may select within the user interface that affects other aspects of the app.