### PR TITLE
Handle case where keystore.properties file is not needed

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -129,15 +129,19 @@ def jscFlavor = 'org.webkit:android-jsc:+'
  */
 def enableHermes = project.ext.react.get("enableHermes", false);
 
-// Create a variable called keystorePropertiesFile, and initialize it to your
-// keystore.properties file, in the rootProject folder.
-def keystorePropertiesFile = rootProject.file("keystore.properties")
+def keystorePropertiesFileExists = file(rootProject.file("keystore.properties")).exists();
 
-// Initialize a new Properties() object called keystoreProperties.
-def keystoreProperties = new Properties()
+if (keystorePropertiesFileExists) {
+  // Create a variable called keystorePropertiesFile, and initialize it to your
+  // keystore.properties file, in the rootProject folder.
+  def keystorePropertiesFile = rootProject.file("keystore.properties")
 
-// Load your keystore.properties file into the keystoreProperties object.
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+  // Initialize a new Properties() object called keystoreProperties.
+  def keystoreProperties = new Properties()
+
+  // Load your keystore.properties file into the keystoreProperties object.
+  keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -165,10 +169,12 @@ android {
     }
     signingConfigs {
         release {
-          storeFile file(keystoreProperties["STOPCOVID_UPLOAD_STORE_FILE"])
-          storePassword keystoreProperties["STOPCOVID_UPLOAD_STORE_PASSWORD"]
-          keyAlias keystoreProperties["STOPCOVID_UPLOAD_KEY_ALIAS"]
-          keyPassword keystoreProperties["STOPCOVID_UPLOAD_KEY_PASSWORD"]
+          if(keystorePropertiesFileExists) {
+            storeFile file(keystoreProperties["STOPCOVID_UPLOAD_STORE_FILE"])
+            storePassword keystoreProperties["STOPCOVID_UPLOAD_STORE_PASSWORD"]
+            keyAlias keystoreProperties["STOPCOVID_UPLOAD_KEY_ALIAS"]
+            keyPassword keystoreProperties["STOPCOVID_UPLOAD_KEY_PASSWORD"]
+          }
         }
     }
     buildTypes {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,7 +36,7 @@ lane :default_changelog do |options|
 end
 
 lane :ensure_keystore_properties do
-  file_exists = File.exist? File.expand_path "../android/keystored.properties"
+  file_exists = File.exist? File.expand_path "../android/keystore.properties"
 
   UI.user_error!("keystore.properties file is missing!") unless file_exists
 end


### PR DESCRIPTION
Some builds don't require the keystore.properties file. This checks for the file before loading in build.gradle, so only people who are building release builds will be prompted for it.