### PR TITLE
 color contrast fix for the Button component

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -122,7 +122,7 @@ export const Button = ({
   }
   return (
     <TouchableOpacity
-      activeOpacity={0.6}
+      activeOpacity={0.8}
       onPress={onPressHandler}
       style={styles.stretch}
       disabled={disabled}


### PR DESCRIPTION
Fixes #600

similar to fixing other buttons, this fix ensures that the variants of the `Button` component that we use are also meeting contrast requirements when pressed. 

Requirement: Above 4.5:1

![Capture d’écran, le 2020-07-10 à 09 26 09](https://user-images.githubusercontent.com/5230720/87159739-cf2a7700-c28f-11ea-9d23-bb23415b2797.png)
![Capture d’écran, le 2020-07-10 à 09 26 32](https://user-images.githubusercontent.com/5230720/87159741-cf2a7700-c28f-11ea-8471-537b24d0d43e.png)
