### PR TITLE
Add lane for downloading symbols for ios builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,7 +109,7 @@ platform :ios do
     download_dsyms(
       version: options[:version],
       build_number: options[:build_number],
-      output_directory: "./dsyms"
+      output_directory: "./build/dsyms"
     )
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -102,6 +102,16 @@ platform :ios do
       }
     )
   end
+
+  lane :download_symbols do |options|
+    UI.user_error!("You must specify a version") unless options[:version]
+    UI.user_error!("You must specify a build_number") unless options[:build_number]
+    download_dsyms(
+      version: options[:version],
+      build_number: options[:build_number],
+      output_directory: "./dsyms"
+    )
+  end
 end
 
 platform :android do

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -44,6 +44,11 @@ Submit a new Covid Alert beta build to Apple TestFlight
 fastlane ios local
 ```
 Builds a local iOS adhoc .ipa
+### ios download_symbols
+```
+fastlane ios download_symbols
+```
+
 
 ----
 


### PR DESCRIPTION
TODO: check for existence of build/dsyms folder and create if not found