### PR TITLE
Explicitly set VersionName and VersionCode on Internal Track releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,7 +135,9 @@ platform :android do
     upload_to_play_store(
       track: 'internal',
       skip_upload_apk: true,
-      aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
+      aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
+      version_name: versionName,
+      version_code: versionCode
     )
 
     create_github_release(platform: "Android")


### PR DESCRIPTION
This should set the VersionName using the convention `VERSION_NAME (VERSION_CODE)` ie `1.0 (33)`