### PR TITLE
Enforce a minimum time between reminder notifications for data upload

### DIFF
--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -28,6 +28,11 @@ export function minutesFromNow(date: Date) {
   return Math.round((currentTime - date.getTime()) / oneMinuteMs);
 }
 
+export function minutesBetween(date1: Date, date2: Date): number {
+  const oneMinuteMs = 1000 * 60;
+  return (date2.getTime() - date1.getTime()) / oneMinuteMs;
+}
+
 export function startOfDay(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }


### PR DESCRIPTION
Closes #629. Set the minimum time to 180 minutes for now, but this should be informed by research.

Here is how I tested this:

## Test 1 
- set `MINIMUM_REMINDER_INTERVAL_MINUTES = 180`
- did a fresh install
- entered a 8-digit number
- did not upload data
- closed app from task manager
- add call to `exposureNotificationService.updateExposureStatusInBackground()` that fires when the app starts, verified this by `console.log`ing the new call and the from the `updateExposureStatusInBackground` function
- opened app
- saw an upload reminder notification
- dismissed notification
- closed app from task manager
- opened app
- saw log indicating I am in the `updateExposureStatusInBackground` function
- no notification fires!
- closed app from task manager

## Test 2
- set `MINIMUM_REMINDER_INTERVAL_MINUTES = 2`
- opened app
- I get a notification!
- dismissed notification 
- closed app from task manager
- opened app
- no notification!
- closed app from task manager
- waited 2 minutes
- opened app
- I get a notification!