### PR TITLE
Fixed buttons on Android not showing Ripple effect

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -116,7 +116,13 @@ export const Button = ({
 
   if (Platform.OS === 'android') {
     return (
-      <Ripple disabled={disabled} onPress={onPressHandler} backgroundColor={color} borderRadius={borderRadius}>
+      <Ripple
+        disabled={disabled}
+        onPress={onPressHandler}
+        backgroundColor={color}
+        borderRadius={borderRadius}
+        {...accessibilityProps}
+      >
         {content}
       </Ripple>
     );

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -71,7 +71,7 @@ export const Button = ({
 
   const content = (
     <Box
-      borderRadius={5}
+      borderRadius={4}
       alignItems="center"
       justifyContent="center"
       shadowColor="bodyText"

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -14,8 +14,8 @@ import {Theme, palette} from 'shared/theme';
 import {useI18n} from '@shopify/react-i18n';
 
 import {Box} from './Box';
-import {Ripple} from './Ripple';
 import {Icon, IconName} from './Icon';
+import {Ripple} from './Ripple';
 
 export interface ButtonProps {
   text?: string;
@@ -69,14 +69,15 @@ export const Button = ({
     : {};
   const externalArrowIcon = textColor === palette.white ? 'icon-external-arrow-light' : 'icon-external-arrow';
 
+  const borderRadius = 4;
   const content = (
     <Box
-      borderRadius={4}
+      borderRadius={borderRadius}
       alignItems="center"
       justifyContent="center"
       shadowColor="bodyText"
       style={{
-        backgroundColor: color,
+        backgroundColor: Platform.OS === 'ios' ? color : 'transparent',
         minHeight: height,
         borderBottomWidth,
         borderBottomColor: Platform.OS === 'ios' ? palette.fadedWhiteDark : borderBottomColor,
@@ -115,7 +116,7 @@ export const Button = ({
 
   if (Platform.OS === 'android') {
     return (
-      <Ripple rippleContainerBorderRadius={5} onPress={onPressHandler} disabled={disabled} {...accessibilityProps}>
+      <Ripple disabled={disabled} onPress={onPressHandler} backgroundColor={color} borderRadius={borderRadius}>
         {content}
       </Ripple>
     );

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -69,7 +69,7 @@ export const Button = ({
     : {};
   const externalArrowIcon = textColor === palette.white ? 'icon-external-arrow-light' : 'icon-external-arrow';
 
-  const borderRadius = 4;
+  const borderRadius = 5;
   const content = (
     <Box
       borderRadius={borderRadius}

--- a/src/components/ButtonMultiline.tsx
+++ b/src/components/ButtonMultiline.tsx
@@ -62,7 +62,7 @@ export const ButtonMultiline = ({
 
   const content = (
     <Box
-      borderRadius={10}
+      borderRadius={4}
       alignItems="center"
       justifyContent="center"
       style={{backgroundColor: color, minHeight: height, borderWidth, borderColor: buttonColor}}

--- a/src/components/ButtonMultiline.tsx
+++ b/src/components/ButtonMultiline.tsx
@@ -9,13 +9,15 @@ import {
   ViewStyle,
   ActivityIndicator,
   AccessibilityRole,
+  View,
 } from 'react-native';
 import {Theme, palette} from 'shared/theme';
 import {useI18n} from '@shopify/react-i18n';
+import {RectButton} from 'react-native-gesture-handler';
 
 import {Box} from './Box';
-import {Ripple} from './Ripple';
 import {Icon} from './Icon';
+import {Ripple} from './Ripple';
 
 export interface ButtonMultilineProps {
   text?: string;
@@ -59,13 +61,18 @@ export const ButtonMultiline = ({
       }
     : {};
   const externalArrowIcon = textColor === palette.white ? 'icon-external-arrow-light' : 'icon-external-arrow';
-
+  const borderRadius = 4;
   const content = (
     <Box
-      borderRadius={4}
+      borderRadius={borderRadius}
       alignItems="center"
       justifyContent="center"
-      style={{backgroundColor: color, minHeight: height, borderWidth, borderColor: buttonColor}}
+      style={{
+        backgroundColor: Platform.OS === 'ios' ? color : 'transparent',
+        minHeight: height,
+        borderWidth,
+        borderColor: buttonColor,
+      }}
       paddingHorizontal="m"
       paddingVertical="m"
       flexDirection="row"
@@ -116,7 +123,7 @@ export const ButtonMultiline = ({
 
   if (Platform.OS === 'android') {
     return (
-      <Ripple rippleContainerBorderRadius={4} onPress={onPressHandler} {...accessibilityProps}>
+      <Ripple disabled={disabled} onPress={onPressHandler} backgroundColor={color} borderRadius={borderRadius}>
         {content}
       </Ripple>
     );

--- a/src/components/ButtonMultiline.tsx
+++ b/src/components/ButtonMultiline.tsx
@@ -59,7 +59,7 @@ export const ButtonMultiline = ({
       }
     : {};
   const externalArrowIcon = textColor === palette.white ? 'icon-external-arrow-light' : 'icon-external-arrow';
-  const borderRadius = 4;
+  const borderRadius = 10;
   const content = (
     <Box
       borderRadius={borderRadius}

--- a/src/components/ButtonMultiline.tsx
+++ b/src/components/ButtonMultiline.tsx
@@ -9,11 +9,9 @@ import {
   ViewStyle,
   ActivityIndicator,
   AccessibilityRole,
-  View,
 } from 'react-native';
 import {Theme, palette} from 'shared/theme';
 import {useI18n} from '@shopify/react-i18n';
-import {RectButton} from 'react-native-gesture-handler';
 
 import {Box} from './Box';
 import {Icon} from './Icon';

--- a/src/components/ButtonMultiline.tsx
+++ b/src/components/ButtonMultiline.tsx
@@ -123,7 +123,13 @@ export const ButtonMultiline = ({
 
   if (Platform.OS === 'android') {
     return (
-      <Ripple disabled={disabled} onPress={onPressHandler} backgroundColor={color} borderRadius={borderRadius}>
+      <Ripple
+        disabled={disabled}
+        onPress={onPressHandler}
+        backgroundColor={color}
+        borderRadius={borderRadius}
+        {...accessibilityProps}
+      >
         {content}
       </Ripple>
     );

--- a/src/components/ButtonSingleLine.tsx
+++ b/src/components/ButtonSingleLine.tsx
@@ -62,7 +62,7 @@ export const ButtonSingleLine = ({
 
   const content = (
     <Box
-      borderRadius={10}
+      borderRadius={4}
       alignItems="center"
       justifyContent="center"
       style={{

--- a/src/components/ButtonSingleLine.tsx
+++ b/src/components/ButtonSingleLine.tsx
@@ -122,7 +122,13 @@ export const ButtonSingleLine = ({
 
   if (Platform.OS === 'android') {
     return (
-      <Ripple disabled={disabled} onPress={onPressHandler} backgroundColor={color} borderRadius={borderRadius}>
+      <Ripple
+        disabled={disabled}
+        onPress={onPressHandler}
+        backgroundColor={color}
+        borderRadius={borderRadius}
+        {...accessibilityProps}
+      >
         {content}
       </Ripple>
     );

--- a/src/components/ButtonSingleLine.tsx
+++ b/src/components/ButtonSingleLine.tsx
@@ -8,14 +8,16 @@ import {
   ViewStyle,
   ActivityIndicator,
   AccessibilityRole,
+  View,
 } from 'react-native';
 import {Theme, palette} from 'shared/theme';
 import {useI18n} from '@shopify/react-i18n';
+import {RectButton} from 'react-native-gesture-handler';
 
 import {Box} from './Box';
-import {Ripple} from './Ripple';
 import {Icon, IconName} from './Icon';
 import {Text} from './Text';
+import {Ripple} from './Ripple';
 
 export interface ButtonSingleLineProps {
   text?: string;
@@ -59,14 +61,14 @@ export const ButtonSingleLine = ({
       }
     : {};
   const externalArrowIcon = textColor === palette.white ? 'icon-external-arrow-light' : 'icon-external-arrow';
-
+  const borderRadius = 4;
   const content = (
     <Box
-      borderRadius={4}
+      borderRadius={borderRadius}
       alignItems="center"
       justifyContent="center"
       style={{
-        backgroundColor: color,
+        backgroundColor: Platform.OS === 'ios' ? color : 'transparent',
         minHeight: height,
         borderWidth,
         borderColor: buttonColor,
@@ -120,7 +122,7 @@ export const ButtonSingleLine = ({
 
   if (Platform.OS === 'android') {
     return (
-      <Ripple rippleContainerBorderRadius={10} onPress={onPressHandler} {...accessibilityProps}>
+      <Ripple disabled={disabled} onPress={onPressHandler} backgroundColor={color} borderRadius={borderRadius}>
         {content}
       </Ripple>
     );

--- a/src/components/ButtonSingleLine.tsx
+++ b/src/components/ButtonSingleLine.tsx
@@ -8,11 +8,9 @@ import {
   ViewStyle,
   ActivityIndicator,
   AccessibilityRole,
-  View,
 } from 'react-native';
 import {Theme, palette} from 'shared/theme';
 import {useI18n} from '@shopify/react-i18n';
-import {RectButton} from 'react-native-gesture-handler';
 
 import {Box} from './Box';
 import {Icon, IconName} from './Icon';

--- a/src/components/ButtonSingleLine.tsx
+++ b/src/components/ButtonSingleLine.tsx
@@ -59,7 +59,7 @@ export const ButtonSingleLine = ({
       }
     : {};
   const externalArrowIcon = textColor === palette.white ? 'icon-external-arrow-light' : 'icon-external-arrow';
-  const borderRadius = 4;
+  const borderRadius = 10;
   const content = (
     <Box
       borderRadius={borderRadius}

--- a/src/components/InfoButton.tsx
+++ b/src/components/InfoButton.tsx
@@ -103,20 +103,15 @@ export const InfoButton = ({
 
   if (Platform.OS === 'android') {
     return (
-      <RectButton
-        enabled={!disabled}
-        style={{
-          backgroundColor: buttonColor,
-          borderRadius,
-        }}
+      <Ripple
+        disabled={disabled}
         onPress={onPressHandler}
-        rippleColor="rgb(0,0,0)"
-        activeOpacity={0.8}
+        backgroundColor={buttonColor}
+        borderRadius={borderRadius}
+        {...accessibilityProps}
       >
-        <View accessible {...accessibilityProps}>
-          {content}
-        </View>
-      </RectButton>
+        {content}
+      </Ripple>
     );
   }
   return (

--- a/src/components/InfoButton.tsx
+++ b/src/components/InfoButton.tsx
@@ -8,11 +8,9 @@ import {
   ViewStyle,
   ActivityIndicator,
   AccessibilityRole,
-  View,
 } from 'react-native';
 import {Theme, palette} from 'shared/theme';
 import {useI18n} from '@shopify/react-i18n';
-import {RectButton} from 'react-native-gesture-handler';
 
 import {Box} from './Box';
 import {Ripple} from './Ripple';

--- a/src/components/InfoButton.tsx
+++ b/src/components/InfoButton.tsx
@@ -8,9 +8,11 @@ import {
   ViewStyle,
   ActivityIndicator,
   AccessibilityRole,
+  View,
 } from 'react-native';
 import {Theme, palette} from 'shared/theme';
 import {useI18n} from '@shopify/react-i18n';
+import {RectButton} from 'react-native-gesture-handler';
 
 import {Box} from './Box';
 import {Ripple} from './Ripple';
@@ -58,13 +60,18 @@ export const InfoButton = ({
       }
     : {};
   const externalArrowIcon = textColor === palette.white ? 'icon-external-arrow-light' : 'icon-external-arrow';
-
+  const borderRadius = 10;
   const content = (
     <Box
-      borderRadius={10}
+      borderRadius={borderRadius}
       alignItems="center"
       justifyContent="center"
-      style={{minHeight: height, borderWidth, borderColor: buttonColor, backgroundColor: buttonColor}}
+      style={{
+        minHeight: height,
+        borderWidth,
+        borderColor: buttonColor,
+        backgroundColor: Platform.OS === 'ios' ? buttonColor : undefined,
+      }}
       paddingHorizontal="m"
       paddingVertical="m"
       flexDirection="row"
@@ -96,9 +103,20 @@ export const InfoButton = ({
 
   if (Platform.OS === 'android') {
     return (
-      <Ripple rippleContainerBorderRadius={10} onPress={onPressHandler} {...accessibilityProps}>
-        {content}
-      </Ripple>
+      <RectButton
+        enabled={!disabled}
+        style={{
+          backgroundColor: buttonColor,
+          borderRadius,
+        }}
+        onPress={onPressHandler}
+        rippleColor="rgb(0,0,0)"
+        activeOpacity={0.8}
+      >
+        <View accessible {...accessibilityProps}>
+          {content}
+        </View>
+      </RectButton>
     );
   }
   return (

--- a/src/components/Ripple.tsx
+++ b/src/components/Ripple.tsx
@@ -213,10 +213,9 @@ const DEBOUNCE = 200;
 const styles = StyleSheet.create({
   container: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'transparent',
     overflow: 'hidden',
+    zIndex: 1,
   },
-
   ripple: {
     width: RADIUS * 2,
     height: RADIUS * 2,

--- a/src/components/Ripple.tsx
+++ b/src/components/Ripple.tsx
@@ -1,226 +1,37 @@
-import React, {useCallback, useMemo, useRef, useState} from 'react';
-import {
-  Animated,
-  Easing,
-  GestureResponderEvent,
-  I18nManager,
-  LayoutChangeEvent,
-  StyleSheet,
-  TouchableWithoutFeedback,
-  TouchableWithoutFeedbackProps,
-  View,
-} from 'react-native';
+import React from 'react';
+import {View, ViewProps} from 'react-native';
+import {RectButton} from 'react-native-gesture-handler';
 
-interface Props {
-  rippleColor?: string;
-  rippleCentered?: boolean;
-  rippleOpacity?: number;
-  rippleFades?: boolean;
-  rippleExpandDuration?: number;
-  rippleFadeDuration?: number;
-  rippleSize?: number;
-  rippleContainerBorderRadius?: number;
-  children?: React.ReactNode;
+interface RippleProps {
+  children: React.ReactNode;
+  disabled?: boolean;
+  backgroundColor?: string;
+  borderRadius?: number;
+  onPress: () => void;
 }
-
-interface AnimatedRipple {
-  id: number;
-  locationX: number;
-  locationY: number;
-  radius: number;
-  expandAnimatedValue: Animated.Value;
-  fadeAnimatedValue: Animated.Value;
-  timestamp: number;
-}
-
-export type RippleProps = Props & TouchableWithoutFeedbackProps;
 
 export const Ripple = ({
   children,
-  disabled,
-  rippleColor = 'rgb(0, 0, 0)',
-  rippleCentered = false,
-  rippleOpacity = 0.3,
-  rippleExpandDuration = 500,
-  rippleFadeDuration = 200,
-  rippleContainerBorderRadius = 0,
-  rippleSize = 0,
-  ...touchableWithoutFeedbackProps
-}: RippleProps) => {
-  const [width, setWidth] = useState(0);
-  const [height, setHeight] = useState(0);
-  const uuid = useRef(0);
-  const [ripples, setRipples] = useState<AnimatedRipple[]>([]);
-  const [fadings, setFadings] = useState<number[]>([]);
-
-  const startFade = useCallback(
-    (ripple: AnimatedRipple, duration: number) => {
-      if (fadings.indexOf(ripple.id) >= 0) {
-        return;
-      }
-      setFadings([...fadings, ripple.id]);
-      Animated.timing(ripple.fadeAnimatedValue, {
-        toValue: 1,
-        easing: Easing.out(Easing.ease),
-        duration,
-        useNativeDriver: true,
-      }).start(() => {
-        setRipples(ripples.filter(item => item !== ripple));
-      });
-    },
-    [fadings, ripples],
-  );
-
-  const startExpand = useCallback(
-    (event: GestureResponderEvent) => {
-      if (!width || !height) {
-        return;
-      }
-
-      const timestamp = Date.now();
-      if (ripples.length > 0 && timestamp < ripples[ripples.length - 1].timestamp + DEBOUNCE) {
-        return;
-      }
-
-      const w2 = 0.5 * width;
-      const h2 = 0.5 * height;
-
-      const {locationX, locationY} = rippleCentered ? {locationX: w2, locationY: h2} : event.nativeEvent;
-
-      const offsetX = Math.abs(w2 - locationX);
-      const offsetY = Math.abs(h2 - locationY);
-
-      const radius = rippleSize > 0 ? 0.5 * rippleSize : Math.sqrt((w2 + offsetX) ** 2 + (h2 + offsetY) ** 2);
-
-      const id = uuid.current;
-      uuid.current += 1;
-
-      const ripple: AnimatedRipple = {
-        id,
-        locationX,
-        locationY,
-        radius,
-        timestamp,
-        expandAnimatedValue: new Animated.Value(0),
-        fadeAnimatedValue: new Animated.Value(0),
-      };
-
-      Animated.timing(ripple.expandAnimatedValue, {
-        toValue: 1,
-        easing: Easing.out(Easing.ease),
-        duration: rippleExpandDuration,
-        useNativeDriver: true,
-      }).start();
-
-      setRipples(ripples.concat(ripple));
-    },
-    [height, rippleCentered, rippleExpandDuration, rippleSize, ripples, width],
-  );
-
-  const onLayout = useCallback(
-    (event: LayoutChangeEvent) => {
-      const {
-        nativeEvent: {
-          layout: {height, width},
-        },
-      } = event;
-      setWidth(width);
-      setHeight(height);
-      touchableWithoutFeedbackProps.onLayout?.(event);
-    },
-    [touchableWithoutFeedbackProps.onLayout],
-  );
-
-  const onPressIn = useCallback(
-    (event: GestureResponderEvent) => {
-      startExpand(event);
-      touchableWithoutFeedbackProps.onPressIn?.(event);
-    },
-    [startExpand, touchableWithoutFeedbackProps.onPressIn],
-  );
-
-  const onPressOut = useCallback(
-    (event: GestureResponderEvent) => {
-      ripples.forEach(ripple => startFade(ripple, rippleFadeDuration + rippleExpandDuration / 2));
-      touchableWithoutFeedbackProps.onPressOut?.(event);
-    },
-    [rippleExpandDuration, rippleFadeDuration, ripples, startFade, touchableWithoutFeedbackProps.onPressOut],
-  );
-
-  const onPress = useCallback(
-    (event: GestureResponderEvent) => {
-      requestAnimationFrame(() => {
-        touchableWithoutFeedbackProps.onPress?.(event);
-      });
-    },
-    [touchableWithoutFeedbackProps.onPress],
-  );
-
-  const renderRipple = useCallback(
-    ({locationX, locationY, radius, id, expandAnimatedValue, fadeAnimatedValue}: AnimatedRipple) => {
-      const rippleStyle = {
-        top: locationY - RADIUS,
-        [I18nManager.isRTL ? 'right' : 'left']: locationX - RADIUS,
-        backgroundColor: rippleColor,
-        transform: [
-          {
-            scale: expandAnimatedValue.interpolate({
-              inputRange: [0, 1],
-              outputRange: [0.5 / RADIUS, radius / RADIUS],
-            }),
-          },
-        ],
-        opacity: fadeAnimatedValue.interpolate({
-          inputRange: [0, 1],
-          outputRange: [rippleOpacity, 0],
-        }),
-      };
-      return <Animated.View style={[styles.ripple, rippleStyle]} key={id} />;
-    },
-    [rippleColor, rippleOpacity],
-  );
-
-  const style = useMemo(
-    () => [
-      styles.container,
-      {
-        borderRadius: rippleContainerBorderRadius,
-      },
-    ],
-    [rippleContainerBorderRadius],
-  );
-
+  disabled = false,
+  backgroundColor = 'transparent',
+  borderRadius = 4,
+  onPress,
+  ...props
+}: RippleProps & ViewProps) => {
   return (
-    <TouchableWithoutFeedback
-      {...touchableWithoutFeedbackProps}
-      disabled={disabled}
-      onPressIn={onPressIn}
-      onPressOut={onPressOut}
+    <RectButton
+      enabled={!disabled}
+      style={{
+        backgroundColor,
+        borderRadius,
+      }}
       onPress={onPress}
-      onLayout={onLayout}
+      rippleColor="rgb(0,0,0)"
+      activeOpacity={0.8}
     >
-      <Animated.View pointerEvents="box-only">
-        <View style={style}>{ripples.map(renderRipple)}</View>
+      <View accessible {...props}>
         {children}
-      </Animated.View>
-    </TouchableWithoutFeedback>
+      </View>
+    </RectButton>
   );
 };
-
-const RADIUS = 8;
-const DEBOUNCE = 200;
-
-const styles = StyleSheet.create({
-  container: {
-    ...StyleSheet.absoluteFillObject,
-    overflow: 'hidden',
-    zIndex: 1,
-  },
-  ripple: {
-    width: RADIUS * 2,
-    height: RADIUS * 2,
-    borderRadius: RADIUS,
-    overflow: 'hidden',
-    position: 'absolute',
-  },
-});

--- a/src/components/TouchableIcon.tsx
+++ b/src/components/TouchableIcon.tsx
@@ -26,16 +26,7 @@ export const TouchableIcon = ({iconName, iconSize, containerSize = 66, label, on
   );
 
   if (Platform.OS === 'android') {
-    return (
-      <Ripple
-        rippleSize={containerSize}
-        rippleContainerBorderRadius={containerSize}
-        onPress={onPress}
-        {...accessibilityProps}
-      >
-        {content}
-      </Ripple>
-    );
+    return <Ripple onPress={onPress}>{content}</Ripple>;
   }
   return (
     <TouchableOpacity activeOpacity={0.6} onPress={onPress} {...accessibilityProps}>

--- a/src/components/TouchableIcon.tsx
+++ b/src/components/TouchableIcon.tsx
@@ -26,7 +26,11 @@ export const TouchableIcon = ({iconName, iconSize, containerSize = 66, label, on
   );
 
   if (Platform.OS === 'android') {
-    return <Ripple onPress={onPress}>{content}</Ripple>;
+    return (
+      <Ripple onPress={onPress} {...accessibilityProps}>
+        {content}
+      </Ripple>
+    );
   }
   return (
     <TouchableOpacity activeOpacity={0.6} onPress={onPress} {...accessibilityProps}>


### PR DESCRIPTION
Fixes #655 

- Switched from custom Ripple solution to use `RectButton` component from `react-native-gesture-handler` for performance and accessibility.