### PR TITLE
Fix crash when changing front size

### DIFF
--- a/android/app/src/main/java/app/covidshield/MainActivity.kt
+++ b/android/app/src/main/java/app/covidshield/MainActivity.kt
@@ -10,7 +10,7 @@ class MainActivity : ReactActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         SplashScreen.show(this)
-        super.onCreate(savedInstanceState)
+        super.onCreate(null)
     }
 
     /**


### PR DESCRIPTION
This PR fixes crash when changing front size due to `react-native-screens`. 

See https://stackoverflow.com/questions/57709742/unable-to-instantiate-fragment-com-swmansion-rnscreens-screen

Resolve https://github.com/cds-snc/covid-shield-mobile/issues/651 and https://github.com/cds-snc/covid-shield-mobile/issues/607

## How to test?
- Open the app on Android. 
- Go to system Settings, change font size. 
- Back to the app using recent app switcher. 
- Verify that the app won't crash. It refreshes new UI with proper font size.