### PR TITLE
fixed bottom shield height + bottom inset from safearea

### DIFF
--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -58,7 +58,7 @@ const BottomSheetInternal = (
   const onCloseEnd = useCallback(() => setIsExpanded(false), []);
 
   const {width, height} = useWindowDimensions();
-  const snapPoints = [height, Math.max(width, height) * (extraContent ? 0.3 : 0.2)];
+  const snapPoints = [height, extraContent ? 200 + insets.bottom : 140 + insets.bottom];
 
   // Need to add snapPoints to set enough height when BottomSheet is collapsed
   useEffect(() => {


### PR DESCRIPTION
This may fix #322 @nickmly 

- uses a fixed value for shield height instead of a %
- adds values from safearea to accommodate certain phones like the iphone X or other phones with rounded corners, etc. 

To be tested on a myriad of devices.... 

![Capture d’écran, le 2020-07-13 à 14 40 54](https://user-images.githubusercontent.com/5230720/87341590-e4b1d200-c517-11ea-8be9-069f5f668850.png)

To truly fix this, we should find a way to get the height of the shield and assign it to the snapPoint list. 

[Doc for the bottom-sheet code](https://github.com/osdnk/react-native-reanimated-bottom-sheet)