### PR TITLE
Load secrets before dotenv overload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,10 +1,10 @@
 fastlane_version '2.53.1'
 
 before_all do
+  load_secrets
+
   # Load root-level shared .env
   Dotenv.overload '../.env'
-
-  load_secrets
 
   # Pull all tags
   git_pull(only_tags: true)


### PR DESCRIPTION
Fixes a bug from previous PR where the dotenv overload was firing before the secrets override