### PR TITLE
Consume new endpoint to return last 14 days keys after onboarding

### DIFF
--- a/src/services/BackendService/BackendService.spec.ts
+++ b/src/services/BackendService/BackendService.spec.ts
@@ -1,3 +1,4 @@
+import {downloadDiagnosisKeysFile} from '../../bridge/CovidShield';
 import {TemporaryExposureKey} from '../../bridge/ExposureNotification';
 
 import {BackendService} from './BackendService';
@@ -89,7 +90,7 @@ describe('BackendService', () => {
 
   describe('reportDiagnosisKeys', () => {
     it('returns last 14 keys if there is more than 14', async () => {
-      const backendService = new BackendService('http://localhost', 'https://localhost', 'mock', 0);
+      const backendService = new BackendService('http://localhost', 'https://localhost', 'mock', undefined);
       const keys = generateRandomKeys(20);
 
       await backendService.reportDiagnosisKeys(
@@ -113,6 +114,28 @@ describe('BackendService', () => {
         .forEach(value => {
           expect(covidshield.TemporaryExposureKey.create).toHaveBeenCalledWith(expect.objectContaining(value));
         });
+    });
+  });
+
+  describe('retrieveDiagnosisKeys', () => {
+    it('returns keys file for set period', async () => {
+      const backendService = new BackendService('http://localhost', 'https://localhost', 'mock', undefined);
+
+      await backendService.retrieveDiagnosisKeys(18457);
+
+      expect(downloadDiagnosisKeysFile).toHaveBeenCalledWith(
+        'http://localhost/retrieve/302/18457/ac5558fc1fae634d204120b264419c2e308e3b784877d5c42677b8fdbdcb9881',
+      );
+    });
+
+    it('returns keys file for 14 days if period is 0', async () => {
+      const backendService = new BackendService('http://localhost', 'https://localhost', 'mock', undefined);
+
+      await backendService.retrieveDiagnosisKeys(0);
+
+      expect(downloadDiagnosisKeysFile).toHaveBeenCalledWith(
+        'http://localhost/retrieve/302/00000/4c280e204128701f9f17b45f887f93d5a97d6db1dae11bdc33eb14247ae80ffb',
+      );
     });
   });
 });

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -18,6 +18,9 @@ import {BackendInterface, SubmissionKeySet} from './types';
 const MAX_UPLOAD_KEYS = 14;
 const FETCH_HEADERS = {headers: {'Cache-Control': 'no-store'}};
 
+// See https://github.com/cds-snc/covid-shield-server/pull/176
+const LAST_14_DAYS_PERIOD = '00000';
+
 export class BackendService implements BackendInterface {
   retrieveUrl: string;
   submitUrl: string;
@@ -37,9 +40,10 @@ export class BackendService implements BackendInterface {
   }
 
   async retrieveDiagnosisKeys(period: number) {
-    const message = `${MCC_CODE}:${period}:${Math.floor(Date.now() / 1000 / 3600)}`;
+    const periodStr = `${period > 0 ? period : LAST_14_DAYS_PERIOD}`;
+    const message = `${MCC_CODE}:${periodStr}:${Math.floor(Date.now() / 1000 / 3600)}`;
     const hmac = hmac256(message, encHex.parse(this.hmacKey)).toString(encHex);
-    const url = `${this.retrieveUrl}/retrieve/${MCC_CODE}/${period}/${hmac}`;
+    const url = `${this.retrieveUrl}/retrieve/${MCC_CODE}/${periodStr}/${hmac}`;
     captureMessage('retrieveDiagnosisKeys', {period, url});
     return downloadDiagnosisKeysFile(url);
   }

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -82,7 +82,7 @@ describe('ExposureNotificationService', () => {
       .mockImplementation((args: any) => new OriginalDate(args));
 
     await service.updateExposureStatus();
-    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(14);
+    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(1);
   });
 
   it('backfills the right amount of keys for current day', async () => {
@@ -98,7 +98,7 @@ describe('ExposureNotificationService', () => {
       },
     });
     await service.updateExposureStatus();
-    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(0);
+    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(1);
 
     server.retrieveDiagnosisKeys.mockClear();
 
@@ -109,7 +109,7 @@ describe('ExposureNotificationService', () => {
       },
     });
     await service.updateExposureStatus();
-    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(1);
+    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(2);
 
     server.retrieveDiagnosisKeys.mockClear();
 
@@ -120,7 +120,7 @@ describe('ExposureNotificationService', () => {
       },
     });
     await service.updateExposureStatus();
-    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(2);
+    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(3);
   });
 
   it('serializes status update', async () => {


### PR DESCRIPTION
This PR consumes new endpoint to return last 14 days keys in one call. It also removes a couple of logic of using TEST_MODE and force to re-fetch for Android as they are not necessary after this PR. 

Ref https://github.com/cds-snc/covid-shield-mobile/issues/642

## How to test?

Because EN framework on Android doesn't return summary if there is no matchKeysCount, so there will be two test cases:

### If your device has been exposed before (matchKeysCount will be > 0)
- Do a fresh install app, and pass onboarding flow.
- Expect to see these logs. Look for:
  + `retrieveDiagnosisKeys.period` is 0 and the url has `00000` as period https://retrieval.wild-samphire.cdssandbox.xyz/retrieve/302/00000/3ac9969fae5a99c0f052d89478e83c934fab2a1e7ae8d7ca346efbc462a918d1.
  + `currentExposureStatus.lastChecked.period` is today period.
  + `previousExposureStatus.lastChecked.period` is 0 or undefined.

```
[Tue Jul 14 2020 13:57:20.448]  LOG      registerAndroidHeadlessPeriodicTask {}
[Tue Jul 14 2020 13:57:20.448]  LOG      Running "CovidShield" with {"rootTag":21}
[Tue Jul 14 2020 13:57:20.724]  LOG      App.appInit() {}
[Tue Jul 14 2020 13:57:22.845]  LOG      registerPeriodicTask {"result": true}
[Tue Jul 14 2020 13:57:23.894]  LOG      getExposureConfiguration {"exposureConfigurationUrl": "https://retrieval.wild-samphire.cdssandbox.xyz/exposure-configuration/CA.json"}
[Tue Jul 14 2020 13:57:24.513]  INFO     Using downloaded exposureConfiguration.
[Tue Jul 14 2020 13:57:24.519]  INFO     Saving exposure configuration to iOS keychain.
[Tue Jul 14 2020 13:57:24.520]  LOG      retrieveDiagnosisKeys {"period": 0, "url": "https://retrieval.wild-samphire.cdssandbox.xyz/retrieve/302/00000/3ac9969fae5a99c0f052d89478e83c934fab2a1e7ae8d7ca346efbc462a918d1"}
[Tue Jul 14 2020 13:57:24.860]  LOG      performExposureStatusUpdate {"exposureConfiguration": {"attenuationLevelValues": [0, 0, 2, 2, 2, 2, 2, 2], "attenuationWeight": 50, "daysSinceLastExposureLevelValues": [0, 1, 1, 1, 1, 1, 1, 1], "daysSinceLastExposureWeight": 50, "durationLevelValues": [0, 0, 0, 0, 5, 5, 5, 5], "durationWeight": 50, "minimumRiskScore": 1, "transmissionRiskLevelValues": [1, 1, 1, 1, 1, 1, 1, 1], "transmissionRiskWeight": 50}, "keysFileUrls": ["/data/user/0/ca.gc.hcsc.canada.stopcovid/app_24a8ddea-2795-4a12-abf5-da055f849f13/keys.zip"], "lastCheckedPeriod": 18457}
[Tue Jul 14 2020 13:57:26.720]  LOG      summary {"summary": {"_summaryIdx": "23f0f14f-3842-4dc0-880c-d7c3e3a4d064-1594749445739", "daysSinceLastExposure": 2, "matchedKeyCount": 1, "maximumRiskScore": 10}}
[Tue Jul 14 2020 13:57:27.357]  LOG      finalize {"currentExposureStatus": {"lastChecked": {"period": 18457, "timestamp": 1594749447762}, "summary": {"_summaryIdx": "9d795e11-31e6-47fb-b15a-ab25da061c6c-1594749445750", "daysSinceLastExposure": 2, "matchedKeyCount": 1, "maximumRiskScore": 10}, "type": "exposed"}, "previousExposureStatus": {"lastChecked": {"period": 0, "timestamp": 1594749291971}, "summary": {"_summaryIdx": "065c08f3-5c2a-42ac-b598-f84879567d37-1594749289670", "daysSinceLastExposure": 2, "matchedKeyCount": 1, "maximumRiskScore": 10}, "type": "exposed"}}
```
- Terminate the app and re-open.
- Expect to see these logs:
  + Expect there is ONLY one call to `retrieveDiagnosisKeys` with today lastChecked period.
  + The last two logs below (summary and finalize) are optional depending on where your keys are marked as exposed. In my case, today is marked as exposed. That's why I see summary from the framework. 

```
[Tue Jul 14 2020 14:14:44.213]  LOG      App.appInit() {}
[Tue Jul 14 2020 14:14:46.440]  LOG      registerPeriodicTask {"result": true}
[Tue Jul 14 2020 14:14:46.490]  LOG      registerPeriodicTask {"result": true}
[Tue Jul 14 2020 14:14:47.280]  LOG      getExposureConfiguration {"exposureConfigurationUrl": "https://retrieval.wild-samphire.cdssandbox.xyz/exposure-configuration/CA.json"}
[Tue Jul 14 2020 14:14:47.416]  INFO     Using downloaded exposureConfiguration.
[Tue Jul 14 2020 14:14:47.432]  INFO     Saving exposure configuration to iOS keychain.
[Tue Jul 14 2020 14:14:47.442]  LOG      retrieveDiagnosisKeys {"period": 18457, "url": "https://retrieval.wild-samphire.cdssandbox.xyz/retrieve/302/18457/6a8a10a7fefbbea6c99cab94ca86701fc8f6a5883c767b541828739f511c1891"}
[Tue Jul 14 2020 14:14:47.577]  LOG      performExposureStatusUpdate {"exposureConfiguration": {"attenuationLevelValues": [0, 0, 2, 2, 2, 2, 2, 2], "attenuationWeight": 50, "daysSinceLastExposureLevelValues": [0, 1, 1, 1, 1, 1, 1, 1], "daysSinceLastExposureWeight": 50, "durationLevelValues": [0, 0, 0, 0, 5, 5, 5, 5], "durationWeight": 50, "minimumRiskScore": 1, "transmissionRiskLevelValues": [1, 1, 1, 1, 1, 1, 1, 1], "transmissionRiskWeight": 50}, "keysFileUrls": ["/data/user/0/ca.gc.hcsc.canada.stopcovid/app_baf05eef-d5d1-49d5-887c-72b19066869d/keys.zip"], "lastCheckedPeriod": 18457}
[Tue Jul 14 2020 14:14:54.946]  LOG      summary {"summary": {"_summaryIdx": "7cba5f76-9449-4194-8a29-e19af1f05c89-1594750488485", "daysSinceLastExposure": 1, "matchedKeyCount": 2, "maximumRiskScore": 10}}
[Tue Jul 14 2020 14:14:55.346]  LOG      finalize {"currentExposureStatus": {"lastChecked": {"period": 18457, "timestamp": 1594750495733}, "summary": {"_summaryIdx": "7cba5f76-9449-4194-8a29-e19af1f05c89-1594750488485", "daysSinceLastExposure": 1, "matchedKeyCount": 2, "maximumRiskScore": 10}, "type": "exposed"}, "previousExposureStatus": {"lastChecked": {"period": 18457, "timestamp": 1594750027638}, "summary": {"_summaryIdx": "061395db-6fc1-41e7-acb0-1dd01a7c9be9-1594750020613", "daysSinceLastExposure": 1, "matchedKeyCount": 2, "maximumRiskScore": 10}, "type": "exposed"}}
```

### If your device has NEVER been exposed before (matchKeysCount will be 0)
- Terminate the app and re-open.
- Expect to see these logs. Look for:
  + `retrieveDiagnosisKeys.period` is 0 and the url has `00000` as period https://retrieval.wild-samphire.cdssandbox.xyz/retrieve/302/00000/3ac9969fae5a99c0f052d89478e83c934fab2a1e7ae8d7ca346efbc462a918d1.
  + `currentExposureStatus.lastChecked.period` is today period.
  + `previousExposureStatus.lastChecked.period` is 0 or undefined.
  + There is no `summary` and `finalize` call.

```
[Tue Jul 14 2020 14:29:07.993]  LOG      App.appInit() {}
[Tue Jul 14 2020 14:29:10.275]  LOG      registerPeriodicTask {"result": true}
[Tue Jul 14 2020 14:29:10.281]  LOG      registerPeriodicTask {"result": true}
[Tue Jul 14 2020 14:29:22.473]  LOG      getExposureConfiguration {"exposureConfigurationUrl": "http://192.168.0.24:8001/exposure-configuration/CA.json"}
[Tue Jul 14 2020 14:29:25.136]  INFO     Using downloaded exposureConfiguration.
[Tue Jul 14 2020 14:29:26.466]  INFO     Saving exposure configuration to iOS keychain.
[Tue Jul 14 2020 14:29:26.472]  LOG      retrieveDiagnosisKeys {"period": 0, "url": "http://192.168.0.24:8001/retrieve/302/00000/4a416cadb7fa0e562173496b1c7389c0352eeb6154e4e57a5eb4f3a04b358736"}
[Tue Jul 14 2020 14:29:26.502]  LOG      performExposureStatusUpdate {"exposureConfiguration": {"attenuationLevelValues": [0, 0, 2, 2, 2, 2, 2, 2], "attenuationWeight": 50, "daysSinceLastExposureLevelValues": [0, 1, 1, 1, 1, 1, 1, 1], "daysSinceLastExposureWeight": 50, "durationLevelValues": [0, 0, 0, 0, 5, 5, 5, 5], "durationWeight": 50, "minimumRiskScore": 1, "transmissionRiskLevelValues": [1, 1, 1, 1, 1, 1, 1, 1], "transmissionRiskWeight": 50}, "keysFileUrls": ["/data/user/0/ca.gc.hcsc.canada.stopcovid/app_929fa9d0-23bc-4f37-acfa-281c3401570e/keys.zip"], "lastCheckedPeriod": 18457}
```
- Terminate and re-open the app again. 
- Expect to see the same request which `00000` is the period. 


