### PR TITLE
Improve BackgroundSchedulerService internval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ RETRIEVE_URL=https://retrieval.covidshield.app
 HMAC_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 MCC_CODE=302
 TRANSMISSION_RISK_LEVEL=2
-MINIMUM_FETCH_INTERVAL=15
 
 TEST_MODE=false
 MOCK_SERVER=false

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -20,8 +20,6 @@ export const MCC_CODE = parseInt(Config.MCC_CODE, 10) || 302;
 
 export const TRANSMISSION_RISK_LEVEL = parseInt(Config.TRANSMISSION_RISK_LEVEL, 10);
 
-export const MINIMUM_FETCH_INTERVAL = parseInt(Config.MINIMUM_FETCH_INTERVAL, 10);
-
 export const TEST_MODE = Config.TEST_MODE === 'true' || false;
 
 export const MOCK_SERVER = Config.MOCK_SERVER === 'true' || false;

--- a/src/services/BackendService/BackendService.spec.ts
+++ b/src/services/BackendService/BackendService.spec.ts
@@ -118,13 +118,23 @@ describe('BackendService', () => {
   });
 
   describe('retrieveDiagnosisKeys', () => {
+    let spyDate;
+
+    beforeEach(() => {
+      spyDate = jest.spyOn(Date, 'now').mockImplementation(() => 1594764739745);
+    });
+
+    afterEach(() => {
+      spyDate.mockReset();
+    });
+
     it('returns keys file for set period', async () => {
       const backendService = new BackendService('http://localhost', 'https://localhost', 'mock', undefined);
 
       await backendService.retrieveDiagnosisKeys(18457);
 
       expect(downloadDiagnosisKeysFile).toHaveBeenCalledWith(
-        'http://localhost/retrieve/302/18457/ac5558fc1fae634d204120b264419c2e308e3b784877d5c42677b8fdbdcb9881',
+        'http://localhost/retrieve/302/18457/a8527b47523dca5bfe6beb8acea351c43364d49b435a1525bdb0dc7f982dba7a',
       );
     });
 
@@ -134,7 +144,7 @@ describe('BackendService', () => {
       await backendService.retrieveDiagnosisKeys(0);
 
       expect(downloadDiagnosisKeysFile).toHaveBeenCalledWith(
-        'http://localhost/retrieve/302/00000/4c280e204128701f9f17b45f887f93d5a97d6db1dae11bdc33eb14247ae80ffb',
+        'http://localhost/retrieve/302/00000/2fd9e1da09518cf874d1520fe676b8264ac81e2e90efaefaa3a6a8eca060e742',
       );
     });
   });

--- a/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
+++ b/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
@@ -1,6 +1,6 @@
 import BackgroundFetch from 'react-native-background-fetch';
 import {Platform} from 'react-native';
-import {MINIMUM_FETCH_INTERVAL} from 'env';
+import {TEST_MODE} from 'env';
 import {captureMessage, captureException} from 'shared/log';
 
 const BACKGROUND_TASK_ID = 'app.covidshield.exposure-notification';
@@ -9,10 +9,15 @@ interface PeriodicTask {
   (): Promise<void>;
 }
 
+// See https://github.com/cds-snc/covid-shield-mobile/issues/642#issuecomment-657783192
+const DEFERRED_JOB_INTERNVAL_IN_MINUTES = 240;
+const EXACT_JOB_INTERNVAL_IN_MINUTES = 90;
+
 const registerPeriodicTask = async (task: PeriodicTask) => {
   BackgroundFetch.configure(
     {
-      minimumFetchInterval: MINIMUM_FETCH_INTERVAL,
+      minimumFetchInterval: TEST_MODE ? EXACT_JOB_INTERNVAL_IN_MINUTES : DEFERRED_JOB_INTERNVAL_IN_MINUTES,
+      forceAlarmManager: TEST_MODE,
       enableHeadless: true,
       startOnBoot: true,
       stopOnTerminate: false,


### PR DESCRIPTION
This PR applies new interval for background job

* Deferred mode: changes to 4 hours interval. We just want to make sure it runs a few times a day just in case some error happens in previous attempts, ex: no internet.
* Exact mode: changes to 1.5 hour interval. It will do 16 requests max.

Ref https://github.com/cds-snc/covid-shield-mobile/issues/642