### PR TITLE
Use latest react-native-background-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lottie-react-native": "^3.4.0",
     "react": "16.11.0",
     "react-native": "0.62.2",
-    "react-native-background-fetch": "^3.0.4",
+    "react-native-background-fetch": "^3.1.0",
     "react-native-config": "^1.1.0",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-linear-gradient": "^2.5.6",

--- a/patches/react-native-background-fetch+3.1.0.patch
+++ b/patches/react-native-background-fetch+3.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-background-fetch/android/build.gradle b/node_modules/react-native-background-fetch/android/build.gradle
-index e4470f3..d2b16da 100644
+index e4470f3..0c0df0c 100644
 --- a/node_modules/react-native-background-fetch/android/build.gradle
 +++ b/node_modules/react-native-background-fetch/android/build.gradle
 @@ -27,5 +27,5 @@ repositories{
@@ -7,5 +7,5 @@ index e4470f3..d2b16da 100644
  dependencies {
      implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 -    implementation(group: 'com.transistorsoft', name:'tsbackgroundfetch', version: '+')
-+    api(group: 'com.transistorsoft', name:'tsbackgroundfetch', version: '+')
++    api fileTree(include: ['*.aar'], dir: 'libs/com/transistorsoft/tsbackgroundfetch/0.4.5')
  }

--- a/patches/react-native-background-fetch+3.1.0.patch
+++ b/patches/react-native-background-fetch+3.1.0.patch
@@ -1,11 +1,11 @@
 diff --git a/node_modules/react-native-background-fetch/android/build.gradle b/node_modules/react-native-background-fetch/android/build.gradle
-index 9b3d82e..6f9fa7a 100644
+index e4470f3..d2b16da 100644
 --- a/node_modules/react-native-background-fetch/android/build.gradle
 +++ b/node_modules/react-native-background-fetch/android/build.gradle
-@@ -29,5 +29,5 @@ dependencies {
+@@ -27,5 +27,5 @@ repositories{
+ 
+ dependencies {
      implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-     //implementation(group: 'com.transistorsoft', name:'tsbackgroundfetch', version: '+')
-     // tsbackgroundfetch.aar
--    implementation fileTree(include: ['*.aar'], dir: 'libs')
-+    api fileTree(include: ['*.aar'], dir: 'libs')
+-    implementation(group: 'com.transistorsoft', name:'tsbackgroundfetch', version: '+')
++    api(group: 'com.transistorsoft', name:'tsbackgroundfetch', version: '+')
  }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7167,10 +7167,10 @@ react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-background-fetch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-native-background-fetch/-/react-native-background-fetch-3.0.4.tgz#0b1e8b282e482343ce7f478ffb94cb72dfde054a"
-  integrity sha512-ZUfwFPDvTRK4Tkl59Is9t2L8cekgRIUA1jNAzMjNrH2O9hpPJ3jYGzfp/+ipxlVZIs+Y83KsgNbL3g7R83r6zw==
+react-native-background-fetch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-background-fetch/-/react-native-background-fetch-3.1.0.tgz#5ec182662e76bd8257f21c6f65cdcb73e87a0708"
+  integrity sha512-dnrfX3Od4r3aKuRSwDkpaPFXc3dYD5DbIW7CWC41M1CdEZEXNIWfZRvJPMVa72iflOzAh68ZTfZ3PgBK/NDtsQ==
   dependencies:
     fast-plist "^0.1.2"
     plist "^3.0.1"


### PR DESCRIPTION
Fix below error due to bad code in old library. 

```
java.lang.RuntimeException: WakeLock under-locked TSBackgroundFetch::react-native-background-fetch
  at android.os.PowerManager$WakeLock.release(PowerManager.java:1954)
  at android.os.PowerManager$WakeLock.release(PowerManager.java:1924)
  at com.transistorsoft.tsbackgroundfetch.FetchAlarmReceiver$1.finish(FetchAlarmReceiver.java:27)
  at com.transistorsoft.tsbackgroundfetch.BGTask.finish(BGTask.java:83)
  at com.transistorsoft.tsbackgroundfetch.BackgroundFetch.finish(BackgroundFetch.java:178)
  at com.transistorsoft.rnbackgroundfetch.RNBackgroundFetchModule.finish(RNBackgroundFetchModule.java:82)
  at java.lang.reflect.Method.invoke(Method.java:-2)
  at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
  at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:151)
  at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java:-2)
  at android.os.Handler.handleCallback(Handler.java:751)
  at android.os.Handler.dispatchMessage(Handler.java:95)
  at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
  at android.os.Looper.loop(Looper.java:154)
  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
  at java.lang.Thread.run(Thread.java:762)
```

Ref https://github.com/cds-snc/covid-shield-mobile/issues/642