### PR TITLE
Fix i18n calls `start` again after changing locale

### DIFF
--- a/src/locale/locale.tsx
+++ b/src/locale/locale.tsx
@@ -1,10 +1,14 @@
-import React, {createContext, useMemo, useContext} from 'react';
-import {I18n, I18nManager} from '@shopify/react-i18n';
+import React, {createContext, useMemo, useContext, useRef, useEffect} from 'react';
+import {I18n as ReactI18n, I18nManager} from '@shopify/react-i18n';
 import {createStorageService, useStorage} from 'services/StorageService';
 import {captureException} from 'shared/log';
 
 import LOCALES from './translations';
 import FALLBACK_LOCALE from './translations/en.json';
+
+export interface I18n {
+  translate(id: string): string;
+}
 
 const I18nContext = createContext<I18n | undefined>(undefined);
 
@@ -16,7 +20,7 @@ export const createI18n = (locale: string) => {
     },
   });
   i18nManager.register({id: 'global'});
-  return new I18n([LOCALES[locale], FALLBACK_LOCALE], {...i18nManager.details});
+  return new ReactI18n([LOCALES[locale], FALLBACK_LOCALE], {...i18nManager.details});
 };
 
 export const createBackgroundI18n = async (forceLocale?: string) => {
@@ -41,4 +45,21 @@ export const useI18n = () => {
   return useContext(I18nContext)!!;
 };
 
-export {I18n};
+/**
+ * A wrapper for i18n which doesn't return new reference even i18n is updated
+ */
+export const useI18nRef = () => {
+  const i18n = useI18n();
+  const ref = useRef(i18n);
+
+  useEffect(() => {
+    ref.current = i18n;
+  }, [i18n]);
+
+  return useMemo<I18n>(
+    () => ({
+      translate: (id: string) => ref.current.translate(id),
+    }),
+    [],
+  );
+};

--- a/src/locale/locale.tsx
+++ b/src/locale/locale.tsx
@@ -6,9 +6,7 @@ import {captureException} from 'shared/log';
 import LOCALES from './translations';
 import FALLBACK_LOCALE from './translations/en.json';
 
-export interface I18n {
-  translate(id: string): string;
-}
+export type I18n = Pick<ReactI18n, 'locale' | 'translate'>;
 
 const I18nContext = createContext<I18n | undefined>(undefined);
 
@@ -56,10 +54,14 @@ export const useI18nRef = () => {
     ref.current = i18n;
   }, [i18n]);
 
-  return useMemo<I18n>(
-    () => ({
-      translate: (id: string) => ref.current.translate(id),
-    }),
-    [],
-  );
+  return useMemo<I18n>(() => {
+    return {
+      get locale() {
+        return ref.current.locale;
+      },
+      translate: (id: any, optionsOrReplacements?: any, replacements?: any) => {
+        return ref.current.translate(id, optionsOrReplacements, replacements) as any;
+      },
+    };
+  }, []);
 };

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -1,6 +1,6 @@
 import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import AsyncStorage from '@react-native-community/async-storage';
-import {useI18n} from 'locale';
+import {useI18nRef} from 'locale';
 import ExposureNotification, {Status as SystemStatus} from 'bridge/ExposureNotification';
 import {AppState, AppStateStatus} from 'react-native';
 import SecureStorage from 'react-native-sensitive-info';
@@ -35,7 +35,7 @@ export const ExposureNotificationServiceProvider = ({
   secureStorage,
   children,
 }: ExposureNotificationServiceProviderProps) => {
-  const i18n = useI18n();
+  const i18n = useI18nRef();
   const exposureNotificationService = useMemo(
     () =>
       new ExposureNotificationService(


### PR DESCRIPTION
This PR Fix i18n calling start after changing locale.

We need to make sure: 
- `performExposureStatusUpdate` only calls once after changing languages. 
- Notification is shown with correct locale. 

Resolves https://github.com/cds-snc/covid-shield-mobile/issues/707

## How to test?
- Open the app.
- In Demo Mode, do:
  + Toggle language between English and French. 
  + Verify that `performExposureStatusUpdate` isn't called. 
- In `src/services/ExposureNotificationService/ExposureNotificationService.ts`, change to 
```ts
  async updateExposureStatus(): Promise<void> {
    this.processNotification(); // << add this line
    if (this.exposureStatusUpdatePromise) return this.exposureStatusUpdatePromise;
    const cleanUpPromise = <T>(input: T): T => {
      this.exposureStatusUpdatePromise = null;
      return input;
    };
    this.exposureStatusUpdatePromise = this.performExposureStatusUpdate().then(cleanUpPromise, cleanUpPromise);
    return this.exposureStatusUpdatePromise;
  }
```
- In `src/testMode/DemoMode.tsx`, change to 
```ts
const ScreenRadioSelector = () => {
  const exposureNotificationService = useExposureNotificationService(); // << add this line
  const [, updateExposureStatus] = useExposureStatus(); // << add this line
  const {forceScreen, setForceScreen} = useStorage();
  const screenData = [
    {displayName: 'None', value: 'None'},
    {displayName: 'Exposed', value: 'ExposureView'},
    {displayName: 'Diagnosed Share Data', value: 'DiagnosedShareView'},
  ];
  return (
    <Box
      marginTop="l"
      paddingHorizontal="m"
      borderRadius={10}
      backgroundColor="infoBlockNeutralBackground"
      accessibilityRole="radiogroup"
    >
      {screenData.map(x => {
        return (
          <RadioButton
            key={x.displayName}
            selected={forceScreen === x.value}
            onPress={value => {
              // add below switch
              switch (value) {
                case 'None':
                  exposureNotificationService.exposureStatus.set({
                    type: 'monitoring',
                  });
                  break;
                case 'ExposureView':
                  exposureNotificationService.exposureStatus.set({
                    type: 'exposed',
                    summary: {daysSinceLastExposure: 1, matchedKeyCount: 1, maximumRiskScore: 1},
                  });
                  break;
                default:
                  return;
              }
              updateExposureStatus();
              setForceScreen(value);
            }}
            name={x.displayName}
            value={x.value}
          />
        );
      })}
    </Box>
  );
};
```
- In Demo Mode, do:
  + Choose English.
  + Change `Force screen` to `Exposed`, expect notification shown as English.
  + Change `Force screen` back to `None`, dismiss notification.
  + Choose French.
  + Change `Force screen` to `Exposed`, expect notification shown as French. 

