### PR TITLE
Adding json schema validation for the exposure configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "buffer": "^5.6.0",
     "crypto-js": "^3.0.0",
     "intl": "^1.2.5",
+    "jsonschema": "^1.2.6",
     "lottie-ios": "3.1.8",
     "lottie-react-native": "^3.4.0",
     "react": "16.11.0",
@@ -58,6 +59,7 @@
     "reanimated-bottom-sheet": "^1.0.0-alpha.20",
     "rn-faded-scrollview": "^1.0.8",
     "tweetnacl": "^1.0.3",
+    "url": "^0.11.0",
     "yarn": "^1.22.4"
   },
   "devDependencies": {

--- a/src/services/ExposureNotificationService/ExposureConfigurationDefault.json
+++ b/src/services/ExposureNotificationService/ExposureConfigurationDefault.json
@@ -1,0 +1,47 @@
+{
+  "minimumRiskScore": 1,
+  "attenuationLevelValues": [
+    0,
+    0,
+    2,
+    2,
+    2,
+    2,
+    2,
+    2
+  ],
+  "attenuationWeight": 50,
+  "daysSinceLastExposureLevelValues": [
+    0,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1
+  ],
+  "daysSinceLastExposureWeight": 50,
+  "durationLevelValues": [
+    0,
+    0,
+    0,
+    0,
+    5,
+    5,
+    5,
+    5
+  ],
+  "durationWeight": 50,
+  "transmissionRiskLevelValues": [
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1
+  ],
+  "transmissionRiskWeight": 50
+}

--- a/src/services/ExposureNotificationService/ExposureConfigurationSchema.json
+++ b/src/services/ExposureNotificationService/ExposureConfigurationSchema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Covid Alert Exposure Configuration Schema",
+  "type": "object",
+  "properties": {
+    "minimumRiskScore" : {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 4096
+    },
+    "attenuationLevelValues": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 8
+      },
+      "minItems": 8,
+      "maxItems": 8
+    },
+    "attenuationWeight": {
+      "type" : "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "daysSinceLastExposureLevelValues" : {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 8
+      },
+      "minItems": 8,
+      "maxItems": 8
+    },
+    "daysSinceLastExposureWeight": {
+      "type" : "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "durationLevelValues" : {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 8
+      },
+      "minItems": 8,
+      "maxItems": 8
+    },
+    "durationWeight": {
+      "type" : "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "transmissionRiskLevelValues" : {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 8
+      },
+      "minItems": 8,
+      "maxItems": 8
+    },
+    "transmissionRiskWeight": {
+      "type" : "integer",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "required": [ "minimumRiskScore",
+    "attenuationLevelValues", "attenuationWeight",
+    "daysSinceLastExposureLevelValues", "daysSinceLastExposureWeight",
+    "durationLevelValues", "durationWeight",
+    "transmissionRiskLevelValues", "transmissionRiskWeight"
+  ]
+}

--- a/src/services/ExposureNotificationService/ExposureConfigurationValidator.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureConfigurationValidator.spec.ts
@@ -1,0 +1,14 @@
+import {ExposureConfigurationValidator} from './ExposureConfigurationValidator';
+import exposureConfigurationDefault from './ExposureConfigurationDefault.json';
+import exposureConfigurationSchema from './ExposureConfigurationSchema.json';
+
+describe('ExposureConfigurationValidator', () => {
+  it('validates the default config', async () => {
+    const result = new ExposureConfigurationValidator().validateExposureConfiguration(
+      exposureConfigurationDefault,
+      exposureConfigurationSchema,
+    );
+
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/src/services/ExposureNotificationService/ExposureConfigurationValidator.ts
+++ b/src/services/ExposureNotificationService/ExposureConfigurationValidator.ts
@@ -1,0 +1,25 @@
+import {Schema, Validator, ValidatorResult} from 'jsonschema';
+
+import {ExposureConfiguration} from '../../bridge/ExposureNotification';
+
+export class ExposureConfigurationValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ExposureConfigurationValidationError';
+  }
+}
+
+export class ExposureConfigurationValidator {
+  validateExposureConfiguration(exposureConfiguration: ExposureConfiguration, schema: Schema): ValidatorResult {
+    const validator = new Validator();
+    const validatorResult = validator.validate(exposureConfiguration, schema);
+    if (!validatorResult.valid) {
+      console.log('invalid json');
+      console.log(validatorResult.errors.toString());
+      throw new ExposureConfigurationValidationError(
+        `Invalid Exposure Configuration JSON. ${validatorResult.errors.toString()}`,
+      );
+    }
+    return validatorResult;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5578,6 +5578,11 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+jsonschema@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.6.tgz#52b0a8e9dc06bbae7295249d03e4b9faee8a0c0b"
+  integrity sha512-SqhURKZG07JyKKeo/ir24QnS4/BV7a6gQy93bUSe4lUdNp0QNpIz2c9elWJQ9dpc5cQYY6cvCzgRwy0MQCLyqA==
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -7108,6 +7113,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -7140,6 +7150,11 @@ query-string@^6.12.1:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -8776,6 +8791,14 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 use-subscription@^1.0.0, use-subscription@^1.4.0:
   version "1.4.1"


### PR DESCRIPTION
This will validate the downloaded exposure configuration against a pre-defined json schema that is included in the app.

If the downloaded EN config fails, the app will use a default config that is included in the app.