### PR TITLE
Check for screen reader on initial app load

### DIFF
--- a/src/services/AccessibilityService/AccessibilityServiceProvider.tsx
+++ b/src/services/AccessibilityService/AccessibilityServiceProvider.tsx
@@ -25,7 +25,7 @@ export const AccessibilityServiceProvider = ({children}: AccessibilityServicePro
       .then((enabled: any) => {
         setScreenReaderEnabled(enabled);
       })
-      .catch((error: any) => {
+      .catch(() => {
         setScreenReaderEnabled(false);
       });
     AccessibilityInfo.addEventListener('screenReaderChanged', handleScreenReaderToggled);

--- a/src/services/AccessibilityService/AccessibilityServiceProvider.tsx
+++ b/src/services/AccessibilityService/AccessibilityServiceProvider.tsx
@@ -21,9 +21,13 @@ export const AccessibilityServiceProvider = ({children}: AccessibilityServicePro
       setScreenReaderEnabled(screenReaderEnabled);
     };
     // for initial app start
-    AccessibilityInfo.isScreenReaderEnabled().then((enabled: any) => {
-      setScreenReaderEnabled(enabled);
-    });
+    AccessibilityInfo.isScreenReaderEnabled()
+      .then((enabled: any) => {
+        setScreenReaderEnabled(enabled);
+      })
+      .catch((error: any) => {
+        setScreenReaderEnabled(false);
+      });
     AccessibilityInfo.addEventListener('screenReaderChanged', handleScreenReaderToggled);
     return () => {
       AccessibilityInfo.removeEventListener('screenReaderChanged', handleScreenReaderToggled);

--- a/src/services/AccessibilityService/AccessibilityServiceProvider.tsx
+++ b/src/services/AccessibilityService/AccessibilityServiceProvider.tsx
@@ -20,6 +20,10 @@ export const AccessibilityServiceProvider = ({children}: AccessibilityServicePro
     const handleScreenReaderToggled = (screenReaderEnabled: any) => {
       setScreenReaderEnabled(screenReaderEnabled);
     };
+    // for initial app start
+    AccessibilityInfo.isScreenReaderEnabled().then((enabled: any) => {
+      setScreenReaderEnabled(enabled);
+    });
     AccessibilityInfo.addEventListener('screenReaderChanged', handleScreenReaderToggled);
     return () => {
       AccessibilityInfo.removeEventListener('screenReaderChanged', handleScreenReaderToggled);


### PR DESCRIPTION
Fixes an issue where the screen reader enabled boolean was set to false even if the app started with the screen reader already enabled. User had to disable/re-enable the screen reader once the app was opened for it to work