### PR TITLE
Removing TRANSMISSION_RISK_LEVEL from .env and setting it as a const.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ SUBMIT_URL=https://submission.covidshield.app
 RETRIEVE_URL=https://retrieval.covidshield.app
 HMAC_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 MCC_CODE=302
-TRANSMISSION_RISK_LEVEL=2
 
 TEST_MODE=false
 MOCK_SERVER=false

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -18,8 +18,6 @@ export const HMAC_KEY = Config.HMAC_KEY;
 
 export const MCC_CODE = parseInt(Config.MCC_CODE, 10) || 302;
 
-export const TRANSMISSION_RISK_LEVEL = parseInt(Config.TRANSMISSION_RISK_LEVEL, 10);
-
 export const TEST_MODE = Config.TEST_MODE === 'true' || false;
 
 export const MOCK_SERVER = Config.MOCK_SERVER === 'true' || false;

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -6,7 +6,7 @@ import {TemporaryExposureKey} from 'bridge/ExposureNotification';
 import nacl from 'tweetnacl';
 import {getRandomBytes, downloadDiagnosisKeysFile} from 'bridge/CovidShield';
 import {blobFetch} from 'shared/fetch';
-import {MCC_CODE, TRANSMISSION_RISK_LEVEL} from 'env';
+import {MCC_CODE} from 'env';
 import {captureMessage, captureException} from 'shared/log';
 import {getMillisSinceUTCEpoch} from 'shared/date-fns';
 
@@ -18,6 +18,7 @@ import {BackendInterface, SubmissionKeySet} from './types';
 
 const MAX_UPLOAD_KEYS = 14;
 const FETCH_HEADERS = {headers: {'Cache-Control': 'no-store'}};
+const TRANSMISSION_RISK_LEVEL = 1;
 
 // See https://github.com/cds-snc/covid-shield-server/pull/176
 const LAST_14_DAYS_PERIOD = '00000';
@@ -104,9 +105,7 @@ export class BackendService implements BackendInterface {
       keys: exposureKeys.map(key =>
         covidshield.TemporaryExposureKey.create({
           keyData: Buffer.from(key.keyData, 'base64'),
-          transmissionRiskLevel:
-            TRANSMISSION_RISK_LEVEL ||
-            key.transmissionRiskLevel /* See transmissionRiskLevel https://developers.google.com/android/exposure-notifications/exposure-notifications-api#temporaryexposurekey */,
+          transmissionRiskLevel: TRANSMISSION_RISK_LEVEL,
           rollingStartIntervalNumber: key.rollingStartIntervalNumber,
           rollingPeriod: key.rollingPeriod,
         }),


### PR DESCRIPTION
There was a risk that the value being used in the `.env` was potentially unknown after the build process, so it's preferable to include this value directly in the code.

There are no varying levels of risk at this time, either the person has been diagnosed (1), or they have not (0). If they have not been diagnosed, their keys will never be uploaded to the server, and therefore this value will never be used.