### PR TITLE
A11y focus issues

### DIFF
--- a/src/components/InfoBlock.tsx
+++ b/src/components/InfoBlock.tsx
@@ -33,7 +33,7 @@ export const InfoBlock = ({
   showButton,
   focusOnTitle,
 }: InfoBlockProps) => {
-  const autoFocusRef = useAccessibilityAutoFocus(focusOnTitle);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(true);
   return (
     <Box borderRadius={10} backgroundColor={backgroundColor} padding="m" alignItems="flex-start">
       {icon && (

--- a/src/components/InfoBlock.tsx
+++ b/src/components/InfoBlock.tsx
@@ -33,7 +33,7 @@ export const InfoBlock = ({
   showButton,
   focusOnTitle,
 }: InfoBlockProps) => {
-  const [, autoFocusRef] = useAccessibilityAutoFocus(true);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(focusOnTitle);
   return (
     <Box borderRadius={10} backgroundColor={backgroundColor} padding="m" alignItems="flex-start">
       {icon && (

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -13,7 +13,7 @@ export type TextProps = RestyleTextProps<Theme> &
 
 export const Text = ({accessibilityAutoFocus = false, focusRef, ...props}: TextProps) => {
   const styledProps = useRestyle(textRestyleFunctions, props);
-  const autoFocusRef = useAccessibilityAutoFocus(accessibilityAutoFocus);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(accessibilityAutoFocus);
   return <RNText accessible ref={focusRef ? focusRef : autoFocusRef} {...styledProps} />;
 };
 

--- a/src/screens/home/components/AllSetView.tsx
+++ b/src/screens/home/components/AllSetView.tsx
@@ -13,7 +13,7 @@ export const AllSetView = ({
   titleText: string;
   bodyText: string;
 }) => {
-  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
   return (
     <BaseHomeView iconName="thumbs-up">
       <Text focusRef={autoFocusRef} variant="bodyTitle" color="bodyText" marginBottom="m" accessibilityRole="header">

--- a/src/screens/home/views/DiagnosedShareView.tsx
+++ b/src/screens/home/views/DiagnosedShareView.tsx
@@ -10,7 +10,7 @@ export const DiagnosedShareView = ({isBottomSheetExpanded}: {isBottomSheetExpand
   const i18n = useI18n();
   const navigation = useNavigation();
   const toDataShare = useCallback(() => navigation.navigate('DataSharing'), [navigation]);
-  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
   return (
     <BaseHomeView iconName="hand-reminder">

--- a/src/screens/home/views/DiagnosedView.tsx
+++ b/src/screens/home/views/DiagnosedView.tsx
@@ -14,7 +14,7 @@ export const DiagnosedView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: b
   const i18n = useI18n();
   const {region} = useStorage();
   const [exposureStatus] = useExposureStatus();
-  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
   if (exposureStatus.type !== 'diagnosed') return null;
 

--- a/src/screens/home/views/ExposureNotificationsDisabledView.tsx
+++ b/src/screens/home/views/ExposureNotificationsDisabledView.tsx
@@ -25,7 +25,7 @@ export const ExposureNotificationsDisabledView = ({isBottomSheetExpanded}: {isBo
     }
     return toSettings();
   };
-  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
   return (
     <BaseHomeView iconName="icon-bluetooth-disabled">
       <Text focusRef={autoFocusRef} variant="bodyTitle" color="bodyText" marginBottom="m" accessibilityRole="header">

--- a/src/screens/home/views/ExposureView.tsx
+++ b/src/screens/home/views/ExposureView.tsx
@@ -30,7 +30,7 @@ export const ExposureView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: bo
     Linking.openURL(getGuidanceURL()).catch(err => console.error('An error occurred', err));
   }, [getGuidanceURL]);
   const onHowToIsolate = useCallback(() => navigation.navigate('HowToIsolate'), [navigation]);
-  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
   const isRegionOntario = region === 'ON';
 
   const getRegionForText = useCallback(() => {

--- a/src/screens/home/views/NoExposureCoveredRegionView.tsx
+++ b/src/screens/home/views/NoExposureCoveredRegionView.tsx
@@ -11,7 +11,7 @@ import {BaseHomeView} from '../components/BaseHomeView';
 export const NoExposureCoveredRegionView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: boolean}) => {
   const i18n = useI18n();
   const {onboardedDatetime, skipAllSet} = useStorage();
-  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
   if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
     return (

--- a/src/screens/home/views/NoExposureNoRegionView.tsx
+++ b/src/screens/home/views/NoExposureNoRegionView.tsx
@@ -12,7 +12,7 @@ export const NoExposureNoRegionView = ({isBottomSheetExpanded}: {isBottomSheetEx
   const i18n = useI18n();
   const {onboardedDatetime, skipAllSet} = useStorage();
 
-  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
   if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
     return (

--- a/src/screens/home/views/NoExposureUncoveredRegionView.tsx
+++ b/src/screens/home/views/NoExposureUncoveredRegionView.tsx
@@ -11,7 +11,7 @@ import {AllSetView} from '../components/AllSetView';
 export const NoExposureUncoveredRegionView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: boolean}) => {
   const i18n = useI18n();
   const {onboardedDatetime, skipAllSet} = useStorage();
-  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
   if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
     return (

--- a/src/screens/nocode/NoCode.tsx
+++ b/src/screens/nocode/NoCode.tsx
@@ -7,6 +7,7 @@ import {useStorage} from 'services/StorageService';
 import {getRegionCase} from 'shared/RegionLogic';
 import {BulletPoint} from 'components/BulletPoint';
 import {SafeAreaView} from 'react-native-safe-area-context';
+import {useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
 
 interface ContentProps {
   title: string;
@@ -14,9 +15,11 @@ interface ContentProps {
   list?: string[];
   externalLinkText?: string;
   externalLinkCTA?: string;
+  navigation: any;
 }
 
-const Content = ({title, body, list, externalLinkText, externalLinkCTA}: ContentProps) => {
+const Content = ({navigation, title, body, list, externalLinkText, externalLinkCTA}: ContentProps) => {
+  const autoFocusRef = useAccessibilityAutoFocus(true, navigation);
   const externalLinkButton =
     externalLinkCTA && externalLinkText ? (
       <ButtonSingleLine
@@ -28,7 +31,7 @@ const Content = ({title, body, list, externalLinkText, externalLinkCTA}: Content
     ) : null;
   return (
     <Box>
-      <Text variant="bodyTitle" color="bodyText" marginBottom="l" accessibilityRole="header" accessibilityAutoFocus>
+      <Text focusRef={autoFocusRef} variant="bodyTitle" color="bodyText" marginBottom="l" accessibilityRole="header">
         {title}
       </Text>
       <TextMultiline variant="bodyText" color="bodyText" marginBottom="l" text={body} />
@@ -51,6 +54,7 @@ export const NoCodeScreen = () => {
     case 'regionNotCovered':
       content = (
         <Content
+          navigation={navigation}
           title={i18n.translate('DataUpload.NoCode.RegionNotCovered.Title')}
           body={i18n.translate('DataUpload.NoCode.RegionNotCovered.Body')}
           list={[
@@ -64,6 +68,7 @@ export const NoCodeScreen = () => {
     case 'regionCovered':
       content = (
         <Content
+          navigation={navigation}
           title={i18n.translate(`DataUpload.NoCode.RegionCovered.${region}.Title`)}
           body={i18n.translate(`DataUpload.NoCode.RegionCovered.${region}.Body`)}
           externalLinkText={i18n.translate(`DataUpload.NoCode.RegionCovered.${region}.CTA`)}
@@ -75,6 +80,7 @@ export const NoCodeScreen = () => {
       content = (
         <>
           <Content
+            navigation={navigation}
             title={i18n.translate('DataUpload.NoCode.NoRegion.Title')}
             body={i18n.translate('DataUpload.NoCode.NoRegion.Body')}
           />

--- a/src/screens/nocode/NoCode.tsx
+++ b/src/screens/nocode/NoCode.tsx
@@ -2,12 +2,12 @@ import React, {useCallback} from 'react';
 import {ScrollView, StyleSheet, Linking} from 'react-native';
 import {Box, Text, TextMultiline, Toolbar, ButtonSingleLine} from 'components';
 import {useI18n} from 'locale';
-import {useNavigation} from '@react-navigation/native';
+import {useNavigation, useFocusEffect} from '@react-navigation/native';
 import {useStorage} from 'services/StorageService';
 import {getRegionCase} from 'shared/RegionLogic';
 import {BulletPoint} from 'components/BulletPoint';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
+import {useAccessibilityAutoFocus, focusOnElement} from 'shared/useAccessibilityAutoFocus';
 
 interface ContentProps {
   title: string;
@@ -15,11 +15,13 @@ interface ContentProps {
   list?: string[];
   externalLinkText?: string;
   externalLinkCTA?: string;
-  navigation: any;
 }
 
-const Content = ({navigation, title, body, list, externalLinkText, externalLinkCTA}: ContentProps) => {
-  const autoFocusRef = useAccessibilityAutoFocus(true, navigation);
+const Content = ({title, body, list, externalLinkText, externalLinkCTA}: ContentProps) => {
+  const [focusRef, autoFocusRef] = useAccessibilityAutoFocus(true);
+  useFocusEffect(() => {
+    focusOnElement(focusRef);
+  });
   const externalLinkButton =
     externalLinkCTA && externalLinkText ? (
       <ButtonSingleLine
@@ -54,7 +56,6 @@ export const NoCodeScreen = () => {
     case 'regionNotCovered':
       content = (
         <Content
-          navigation={navigation}
           title={i18n.translate('DataUpload.NoCode.RegionNotCovered.Title')}
           body={i18n.translate('DataUpload.NoCode.RegionNotCovered.Body')}
           list={[
@@ -68,7 +69,6 @@ export const NoCodeScreen = () => {
     case 'regionCovered':
       content = (
         <Content
-          navigation={navigation}
           title={i18n.translate(`DataUpload.NoCode.RegionCovered.${region}.Title`)}
           body={i18n.translate(`DataUpload.NoCode.RegionCovered.${region}.Body`)}
           externalLinkText={i18n.translate(`DataUpload.NoCode.RegionCovered.${region}.CTA`)}
@@ -80,7 +80,6 @@ export const NoCodeScreen = () => {
       content = (
         <>
           <Content
-            navigation={navigation}
             title={i18n.translate('DataUpload.NoCode.NoRegion.Title')}
             body={i18n.translate('DataUpload.NoCode.NoRegion.Body')}
           />

--- a/src/screens/onboarding/views/ItemView.tsx
+++ b/src/screens/onboarding/views/ItemView.tsx
@@ -1,8 +1,9 @@
-import React, {ReactNode} from 'react';
+import React, {ReactNode, useRef} from 'react';
 import {StyleSheet, Image, ImageSourcePropType} from 'react-native';
 import {Box, Text} from 'components';
 import {useI18n} from 'locale';
-import {useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
+import {focusOnElement} from 'shared/useAccessibilityAutoFocus';
+import {useFocusEffect} from '@react-navigation/native';
 
 import {onboardingData, OnboardingKey} from '../OnboardingContent';
 
@@ -17,16 +18,20 @@ export interface ItemViewProps {
 
 export const ItemView = ({item, image, isActive, altText, header, children}: ItemViewProps) => {
   const i18n = useI18n();
-  const autoFocusRef = useAccessibilityAutoFocus(isActive);
   const total = onboardingData.length;
   const step = i18n.translate('Onboarding.Step');
   const of = i18n.translate('Onboarding.Of');
   const x = onboardingData.indexOf(item) + 1;
   const stepText = `${step} ${x} ${of} ${total}`;
-
+  const textRef = useRef(null);
+  useFocusEffect(() => {
+    if (isActive) {
+      focusOnElement(textRef.current);
+    }
+  });
   return (
     <>
-      <Text focusRef={autoFocusRef} marginBottom="s" marginTop="s" color="gray2">
+      <Text focusRef={textRef} marginBottom="s" marginTop="s" color="gray2">
         {stepText}
       </Text>
       {image ? (

--- a/src/screens/onboarding/views/ItemView.tsx
+++ b/src/screens/onboarding/views/ItemView.tsx
@@ -1,8 +1,8 @@
-import React, {ReactNode, useRef} from 'react';
+import React, {ReactNode} from 'react';
 import {StyleSheet, Image, ImageSourcePropType} from 'react-native';
 import {Box, Text} from 'components';
 import {useI18n} from 'locale';
-import {focusOnElement} from 'shared/useAccessibilityAutoFocus';
+import {focusOnElement, useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
 import {useFocusEffect} from '@react-navigation/native';
 
 import {onboardingData, OnboardingKey} from '../OnboardingContent';
@@ -18,20 +18,19 @@ export interface ItemViewProps {
 
 export const ItemView = ({item, image, isActive, altText, header, children}: ItemViewProps) => {
   const i18n = useI18n();
+  const [focusRef, autoFocusRef] = useAccessibilityAutoFocus(isActive);
   const total = onboardingData.length;
   const step = i18n.translate('Onboarding.Step');
   const of = i18n.translate('Onboarding.Of');
   const x = onboardingData.indexOf(item) + 1;
   const stepText = `${step} ${x} ${of} ${total}`;
-  const textRef = useRef(null);
+
   useFocusEffect(() => {
-    if (isActive) {
-      focusOnElement(textRef.current);
-    }
+    focusOnElement(focusRef);
   });
   return (
     <>
-      <Text focusRef={textRef} marginBottom="s" marginTop="s" color="gray2">
+      <Text focusRef={autoFocusRef} marginBottom="s" marginTop="s" color="gray2">
         {stepText}
       </Text>
       {image ? (

--- a/src/screens/tutorial/views/ItemView.tsx
+++ b/src/screens/tutorial/views/ItemView.tsx
@@ -14,13 +14,13 @@ export interface ItemViewProps {
 
 export const ItemView = ({item, image, isActive}: ItemViewProps) => {
   const i18n = useI18n();
-  const accessibilityAutoFocusRef = useAccessibilityAutoFocus(isActive);
+  const [, autoFocusRef] = useAccessibilityAutoFocus(isActive);
 
   return (
     <>
       <Image
         accessible
-        ref={accessibilityAutoFocusRef}
+        ref={autoFocusRef}
         style={styles.image}
         source={image}
         accessibilityLabel={i18n.translate(`Tutorial.${item}AltText`)}

--- a/src/shared/useAccessibilityAutoFocus.ts
+++ b/src/shared/useAccessibilityAutoFocus.ts
@@ -9,6 +9,14 @@ import {createCancellableCallbackPromise} from './cancellablePromise';
  */
 const AUTO_FOCUS_DELAY = 200;
 
+export const focusOnElement = (elementRef: any) => {
+  const node = findNodeHandle(elementRef);
+  if (!node) {
+    return;
+  }
+  AccessibilityInfo.setAccessibilityFocus(node);
+};
+
 /**
  * Remember to add `accessible={true}` to target component
  */
@@ -20,18 +28,13 @@ export const useAccessibilityAutoFocus = (isActive = true, navigation: any = nul
       if (!isScreenReaderEnabled) {
         return;
       }
-      const node = findNodeHandle(autoFocusRef);
-      if (!node || !isActive) {
-        return;
-      }
-      AccessibilityInfo.setAccessibilityFocus(node);
+      focusOnElement(autoFocusRef);
     },
   );
 
   useEffect(() => {
     if (navigation) {
       const unsubscribe = navigation.addListener('focus', () => {
-        console.log('worked');
         callable();
         return cancelable;
       });

--- a/src/shared/useAccessibilityAutoFocus.ts
+++ b/src/shared/useAccessibilityAutoFocus.ts
@@ -1,4 +1,4 @@
-import {useEffect, useLayoutEffect, useState} from 'react';
+import {useLayoutEffect, useState} from 'react';
 import {AccessibilityInfo, findNodeHandle} from 'react-native';
 
 import {createCancellableCallbackPromise} from './cancellablePromise';
@@ -19,8 +19,9 @@ export const focusOnElement = (elementRef: any) => {
 
 /**
  * Remember to add `accessible={true}` to target component
+ * @returns [Manual focus ref , Auto focus ref]
  */
-export const useAccessibilityAutoFocus = (isActive = true, navigation: any = null) => {
+export const useAccessibilityAutoFocus = (isActive = true) => {
   const [autoFocusRef, setAutoFocusRef] = useState<any>();
   const {callable, cancelable} = createCancellableCallbackPromise(
     () => AccessibilityInfo.isScreenReaderEnabled().then(delay(AUTO_FOCUS_DELAY)),
@@ -32,16 +33,6 @@ export const useAccessibilityAutoFocus = (isActive = true, navigation: any = nul
     },
   );
 
-  useEffect(() => {
-    if (navigation) {
-      const unsubscribe = navigation.addListener('focus', () => {
-        callable();
-        return cancelable;
-      });
-      return unsubscribe;
-    }
-  }, [callable, cancelable, navigation]);
-
   useLayoutEffect(() => {
     if (!autoFocusRef || !isActive) {
       return;
@@ -51,7 +42,7 @@ export const useAccessibilityAutoFocus = (isActive = true, navigation: any = nul
     return cancelable;
   }, [callable, cancelable, autoFocusRef, isActive]);
 
-  return setAutoFocusRef;
+  return [autoFocusRef, setAutoFocusRef];
 };
 
 function delay<T>(timeout: number) {


### PR DESCRIPTION
Fixes #734 and #732 

These issues relate to the navigation not handling the `useLayoutEffect` hook when the screen changes focus. Fixes below allow for calling a function to manually focus on elements after the screen has received focus in certain scenarios where needed. Tested on Android with TalkBack.

- Added `focusOnElement` function to `/src/shared/useAccessibilityAutoFocus.ts` to allow focus on elements from anywhere in code
- `useAccessibilityAutoFocus` now returns an array containing: `[Manual focus ref , Auto focus ref]`