### PR TITLE
Only auto focus if field is empty

### DIFF
--- a/src/screens/datasharing/views/FormView.tsx
+++ b/src/screens/datasharing/views/FormView.tsx
@@ -29,7 +29,12 @@ export const FormView = ({value, onChange, onSuccess, onError}: FormViewProps) =
   return (
     <>
       <Box marginHorizontal="m" marginBottom="l">
-        <Text variant="bodyTitle" color="overlayBodyText" accessibilityRole="header" accessibilityAutoFocus>
+        <Text
+          variant="bodyTitle"
+          color="overlayBodyText"
+          accessibilityRole="header"
+          accessibilityAutoFocus={value === '' ? true : false}
+        >
           {i18n.translate('DataUpload.FormView.Title')}
         </Text>
       </Box>

--- a/src/screens/datasharing/views/FormView.tsx
+++ b/src/screens/datasharing/views/FormView.tsx
@@ -33,6 +33,7 @@ export const FormView = ({value, onChange, onSuccess, onError}: FormViewProps) =
           variant="bodyTitle"
           color="overlayBodyText"
           accessibilityRole="header"
+          // eslint-disable-next-line no-unneeded-ternary
           accessibilityAutoFocus={value === '' ? true : false}
         >
           {i18n.translate('DataUpload.FormView.Title')}


### PR DESCRIPTION
When entering a one-time code the focus was continually jumping back to the header.

This adds a check:

``
If the text input field has a value don't take focus away from the field
``