### PR TITLE
Package bump - @react-native-community/netinfo

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -241,7 +241,7 @@ PODS:
   - React-jsinspector (0.62.2)
   - react-native-config (1.1.0):
     - React
-  - react-native-netinfo (5.9.0):
+  - react-native-netinfo (5.9.5):
     - React
   - react-native-safe-area-context (3.0.2):
     - React
@@ -544,7 +544,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 1540d1c01bb493ae3124ed83351b1b6a155db7da
   React-jsinspector: 512e560d0e985d0e8c479a54a4e5c147a9c83493
   react-native-config: 313a1306066289211579b9655eb81d9a565462d0
-  react-native-netinfo: 7b3c53674ea611b26a7788821f137c6d9d3a038b
+  react-native-netinfo: a53b00d949b6456913aaf507d9dba90c4008c611
   react-native-safe-area-context: b11a34881faac509cad5578726c98161ad4d275c
   react-native-sensitive-info: 4629b223484a08225c3eb088ff3f91b03097b5e5
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@react-native-community/async-storage": "^1.9.0",
     "@react-native-community/masked-view": "^0.1.10",
-    "@react-native-community/netinfo": "^5.9.0",
+    "@react-native-community/netinfo": "^5.9.5",
     "@react-native-community/push-notification-ios": "^1.2.0",
     "@react-navigation/drawer": "^5.7.2",
     "@react-navigation/native": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,10 +1186,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
   integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
 
-"@react-native-community/netinfo@^5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.0.tgz#8bf2b96ce66ecaacab5a1f6f88b41526c9331481"
-  integrity sha512-rzchLeRkJRXw7ILO4OAMqVP33hEJ754FN2qf85+V1th9ozelXezh4DX90lmxk0PgJpZMwHXUNqS2ltsrzmahXg==
+"@react-native-community/netinfo@^5.9.5":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.5.tgz#3bad0d855d2e813be085ec305139d4175c512ccc"
+  integrity sha512-PbSsRmhRwYIMdeVJTf9gJtvW0TVq/hmgz1xyjsrTIsQ7QS7wbMEiv1Eb/M/y6AEEsdUped5Axm5xykq9TGISHg==
 
 "@react-native-community/push-notification-ios@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
Ref: https://github.com/cds-snc/covid-shield-mobile/issues/445

Updating this to the latest.

**Before:** react-native-netinfo (5.9.0) 
**After:** react-native-netinfo (5.9.5)

https://github.com/react-native-community/react-native-netinfo/releases