### PR TITLE
Update @react-native-community/push-notification-ios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ android/app/google-services.json
 
 # generated files
 ios/assets
+
+.env.release

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -314,7 +314,7 @@ PODS:
     - React
   - RNCMaskedView (0.1.10):
     - React
-  - RNCPushNotificationIOS (1.2.0):
+  - RNCPushNotificationIOS (1.3.0):
     - React
   - RNGestureHandler (1.6.1):
     - React
@@ -561,7 +561,7 @@ SPEC CHECKSUMS:
   RNBackgroundFetch: 8dbb63141792f1473e863a0797ffbd5d987af2fc
   RNCAsyncStorage: 453cd7c335ec9ba3b877e27d02238956b76f3268
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
-  RNCPushNotificationIOS: 4d9ffd08f00ef6c1029ebbf4d72fc711eca3ff01
+  RNCPushNotificationIOS: d5fd66aed4e03c6491ca0c6111a03d4f6455ff6c
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNLocalize: b6df30cc25ae736d37874f9bce13351db2f56796
   RNPermissions: 3635b407c15f2fe591bd2101c8f20aa0912caba8

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@react-native-community/async-storage": "^1.9.0",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "^5.9.5",
-    "@react-native-community/push-notification-ios": "^1.2.0",
+    "@react-native-community/push-notification-ios": "^1.3.0",
     "@react-navigation/drawer": "^5.7.2",
     "@react-navigation/native": "^5.3.0",
     "@react-navigation/stack": "^5.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1191,10 +1191,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.5.tgz#3bad0d855d2e813be085ec305139d4175c512ccc"
   integrity sha512-PbSsRmhRwYIMdeVJTf9gJtvW0TVq/hmgz1xyjsrTIsQ7QS7wbMEiv1Eb/M/y6AEEsdUped5Axm5xykq9TGISHg==
 
-"@react-native-community/push-notification-ios@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.2.0.tgz#3353598450a39c42d079603aad2d1c0f9c2c1729"
-  integrity sha512-B5qPb9P/6vvxGGQDePlK/q6NxoZPWSVFtKCQ9jlboP7gNZmf3AAyBhTzrb++s2NSXXogjkGi6vt9df1ipZiawQ==
+"@react-native-community/push-notification-ios@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.3.0.tgz#349095f5dda42f59501316c7ef7896adb8c2a1db"
+  integrity sha512-fXLtDYsDv8CZIF/1pnrLyKv68X1VVgsWQTVdxA4UeYPAGP9OU4XdShD1TsPFWIF5VgabNrnmKl1uEDLw3X+6jA==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
Was 1.2.0
Bumping to 1.3.0

https://github.com/react-native-community/push-notification-ios/releases/tag/v1.3.0

Noting 1.2.2
<img width="500" alt="Screen Shot 2020-07-18 at 1 36 09 PM" src="https://user-images.githubusercontent.com/62242/87858414-b3f8e080-c8fb-11ea-9928-cdf7169a7bd7.png">
