### PR TITLE
One-time-code allow over 8-10 characters

### DIFF
--- a/src/screens/datasharing/views/FormView.tsx
+++ b/src/screens/datasharing/views/FormView.tsx
@@ -53,7 +53,7 @@ export const FormView = ({value, onChange, onSuccess, onError}: FormViewProps) =
         <Button
           loading={loading}
           // @todo update this for 10 digit code
-          disabled={value.length !== 8}
+          disabled={value.length <= 7}
           variant="thinFlat"
           text={i18n.translate('DataUpload.FormView.Action')}
           onPress={handleVerify}


### PR DESCRIPTION
Fixes a bug where the input would allow for 10 characters but the submit button would disable after 8 characters.