### PR TITLE
Adjust landing page image size

### DIFF
--- a/src/screens/landing/LandingScreen.tsx
+++ b/src/screens/landing/LandingScreen.tsx
@@ -25,7 +25,7 @@ export const LandingScreen = () => {
       <Box flex={1} marginBottom="s" style={{...styles.imageBackround}}>
         <Box flex={1} justifyContent="flex-start" alignItems="center" paddingTop="s">
           <Image
-            resizeMode="cover"
+            resizeMode="contain"
             style={{...styles.imagePad}}
             accessible
             source={require('assets/landingintro.png')}


### PR DESCRIPTION
Fixes landing page image for really small phone sizes.

**Before:**
<img width="300" src="https://user-images.githubusercontent.com/62242/87875735-4d2e0280-c9a1-11ea-86b0-a5abb8b6c65a.jpg">

**After + compare to larger screens:**
<img width="500" alt="Screen Shot 2020-07-19 at 9 18 40 AM" src="https://user-images.githubusercontent.com/62242/87875702-122bcf00-c9a1-11ea-940e-945269e3e91b.png">



