### PR TITLE
Remove the "0 days left" text that is shown after the 14 day upload cycle is finished

### DIFF
--- a/src/screens/home/views/DiagnosedView.tsx
+++ b/src/screens/home/views/DiagnosedView.tsx
@@ -26,16 +26,20 @@ export const DiagnosedView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: b
         {i18n.translate('Home.DiagnosedView.Title')}
         {/* No exposure detected */}
       </Text>
-      <Text variant="bodyText" color="bodyText" marginBottom="l">
-        {i18n.translate(pluralizeKey('Home.DiagnosedView.Body1', daysLeft), {number: daysLeft})}
-      </Text>
-      <Text variant="bodyText" color="bodyText" marginBottom="l">
-        {i18n.translate('Home.DiagnosedView.Body2')}
-      </Text>
-      <Text variant="bodyText" color="bodyText" marginBottom="l">
-        {i18n.translate('Home.DiagnosedView.Body3')}
-      </Text>
-      {region === 'ON' ? <Tip /> : null}
+      {daysLeft < 1 ? null : (
+        <>
+          <Text variant="bodyText" color="bodyText" marginBottom="l">
+            {i18n.translate(pluralizeKey('Home.DiagnosedView.Body1', daysLeft), {number: daysLeft})}
+          </Text>
+          <Text variant="bodyText" color="bodyText" marginBottom="l">
+            {i18n.translate('Home.DiagnosedView.Body2')}
+          </Text>
+          <Text variant="bodyText" color="bodyText" marginBottom="l">
+            {i18n.translate('Home.DiagnosedView.Body3')}
+          </Text>
+          {region === 'ON' ? <Tip /> : null}
+        </>
+      )}
     </BaseHomeView>
   );
 };

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -9,7 +9,7 @@ import {
   useStartExposureNotificationService,
 } from 'services/ExposureNotificationService';
 import {useNavigation} from '@react-navigation/native';
-import {daysBetween} from 'shared/date-fns';
+import {daysBetween, getCurrentDate} from 'shared/date-fns';
 import {pluralizeKey} from 'shared/pluralization';
 import {ScrollView} from 'react-native-gesture-handler';
 import {useAccessibilityService} from 'services/AccessibilityService';
@@ -91,10 +91,14 @@ const ShareDiagnosisCode = ({i18n, isBottomSheetExpanded}: {i18n: I18n; isBottom
   const [exposureStatus] = useExposureStatus();
 
   if (exposureStatus.type === 'diagnosed') {
-    const daysLeft = daysBetween(new Date(), new Date(exposureStatus.cycleEndsAt)) - 1;
-    const bodyText =
-      i18n.translate('OverlayOpen.EnterCodeCardBodyDiagnosed') +
-      i18n.translate(pluralizeKey('OverlayOpen.EnterCodeCardDiagnosedCountdown', daysLeft), {number: daysLeft});
+    const daysLeft = daysBetween(getCurrentDate(), new Date(exposureStatus.cycleEndsAt)) - 1;
+    let bodyText = i18n.translate('OverlayOpen.EnterCodeCardBodyDiagnosed');
+    if (daysLeft > 0) {
+      bodyText += i18n.translate(pluralizeKey('OverlayOpen.EnterCodeCardDiagnosedCountdown', daysLeft), {
+        number: daysLeft,
+      });
+    }
+
     return (
       <InfoBlock
         focusOnTitle={isBottomSheetExpanded}


### PR DESCRIPTION
Closes #802. This fix was arrived at after discussion w/ @katewilhelm.  

## Homescreen shown after the user uploads for the last time:
Before (Ontario):
<img width="356" alt="Screen Shot 2020-07-20 at 4 27 45 PM" src="https://user-images.githubusercontent.com/5498428/87992688-070e9700-caa6-11ea-85d7-37da3c607ee6.png">

After (Ontario):
<img width="355" alt="Screen Shot 2020-07-20 at 4 16 01 PM" src="https://user-images.githubusercontent.com/5498428/87992046-9adf6380-caa4-11ea-9fa1-f5fed9719b1f.png">

## Menu shown after the user uploads for the last time:
Before:
<img width="351" alt="Screen Shot 2020-07-20 at 4 29 55 PM" src="https://user-images.githubusercontent.com/5498428/87992800-41783400-caa6-11ea-80a4-8d9ddcad45b4.png">

After:
<img width="349" alt="Screen Shot 2020-07-20 at 4 18 43 PM" src="https://user-images.githubusercontent.com/5498428/87992075-b0548d80-caa4-11ea-81c0-9653f492e387.png">

## Details on local testing
To test this locally, I modified the [`getCurrentDate` fn](https://github.com/cds-snc/covid-shield-mobile/blob/master/src/shared/date-fns.ts#L49). And I commented out the [server request `reportDiagnosisKeys`](https://github.com/cds-snc/covid-shield-mobile/blob/master/src/services/ExposureNotificationService/ExposureNotificationService.ts#L193) on @henrytao-me's advice since it was giving me a 400 error. Here is what I observed before making this PR:

Today: July 20th
-> I upload a one time diagnosis key and agree to share my "random codes"
_homescreen_: "Thank you" screen, "For the next 13 days you'll get a daily notification..."
_menu_: 13 days left

-> I change the source code and fast forward to July 31st
_homescreen_: "Upload random codes" screen
_menu_: 2 days left

-> I upload my random codes
_homescreen_: "Thank you" screen, "For the next 2 days..."
_menu_: 2 days left

-> I fast forward to Aug 1st
_homescreen_: "Upload random codes" screen 
_menu_: 1 day left

-> I upload my random codes
_homescreen_: "Thank you" screen, "Tomorrow you'll get your last notification..."
_menu_: 1 day left

-> I fast forward to Aug 2nd
_homescreen_: "Upload random codes" screen 
_menu_: 0 days left

-> I upload my random codes
_homescreen_: "Thank you" screen, "For the next 0 days you'll get a daily notification..."
_menu_: 0 days left

-> I fast forward to Aug 3
_homescreen_: I am back to monitoring: "No exposure detected" screen
_menu_: "Diagnosed w/ Covid? enter your one-time key..."
