### PR TITLE
Make clock/navigation text visible on iOS when navigating away from Home Screen

### DIFF
--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {StatusBar, Platform} from 'react-native';
+import {StatusBar} from 'react-native';
 import {enableScreens} from 'react-native-screens';
-import {useNavigationState} from '@react-navigation/native';
 import {createStackNavigator} from '@react-navigation/stack';
 import {HomeScreen} from 'screens/home';
 import {TutorialScreen} from 'screens/tutorial';
@@ -22,18 +21,9 @@ const MainStack = createStackNavigator();
 
 const withDarkNav = (Component: React.ElementType) => {
   const ComponentWithDarkNav = (props: any) => {
-    const stackIndex = useNavigationState(state => state.index);
     return (
       <SafeAreaProvider>
-        <StatusBar
-          barStyle={
-            // On iOS 13+ keep light statusbar since the screen will be displayed in a modal with a
-            // dark background.
-            stackIndex > 0 && Platform.OS === 'ios' && parseInt(Platform.Version as string, 10) >= 13 && !Platform.isPad
-              ? 'light-content'
-              : 'dark-content'
-          }
-        />
+        <StatusBar barStyle="dark-content" />
         <Component {...props} />
       </SafeAreaProvider>
     );


### PR DESCRIPTION
Closes #809. I removed the iOS specific logic that used white nav text, this styling does not apply to the navigator we are using now. The navigator was changed in https://github.com/cds-snc/covid-shield-mobile/pull/738.

<img width="354" alt="Screen Shot 2020-07-20 at 10 01 12 PM" src="https://user-images.githubusercontent.com/5498428/88011666-22dd6180-cad5-11ea-9791-c958a668c489.png">
