### PR TITLE
Prioritize expsoure summary by using lastExposureTimestamp

### DIFF
--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
@@ -25,5 +25,10 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: any
         }
       });
     },
+    getPendingExposureSummary: async () => {
+      const summary = await exposureNotificationAPI.getPendingExposureSummary();
+      summary.lastExposureTimestamp = getLastExposureTimestamp(summary);
+      return summary;
+    },
   };
 }

--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
@@ -1,4 +1,5 @@
 import {ExposureNotification} from './types';
+import {getLastExposureTimestamp} from './utils';
 
 export default function ExposureNotificationAdapter(exposureNotificationAPI: any): ExposureNotification {
   return {
@@ -15,6 +16,7 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: any
         for (const diagnosisKeysURL of diagnosisKeysURLs) {
           (async (diagnosisKeysURL: string) => {
             const summary = await exposureNotificationAPI.detectExposure(configuration, [diagnosisKeysURL]);
+            summary.lastExposureTimestamp = getLastExposureTimestamp(summary);
             // first detected exposure is enough
             if (summary.matchedKeyCount > 0) {
               resolve(summary);

--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
@@ -1,6 +1,7 @@
 import {unzip} from 'react-native-zip-archive';
 
 import {ExposureNotification, ExposureSummary} from './types';
+import {getLastExposureTimestamp} from './utils';
 
 export default function ExposureNotificationAdapter(
   exposureNotificationAPI: ExposureNotification,
@@ -23,6 +24,7 @@ export default function ExposureNotificationAdapter(
           `${unzippedLocation}/export.bin`,
           `${unzippedLocation}/export.sig`,
         ]);
+        summary.lastExposureTimestamp = getLastExposureTimestamp(summary);
         // first detected exposure is enough
         if (summary.matchedKeyCount > 0) break;
       }

--- a/src/bridge/ExposureNotification/types.ts
+++ b/src/bridge/ExposureNotification/types.ts
@@ -29,6 +29,7 @@ export interface TemporaryExposureKey {
 
 export interface ExposureSummary {
   daysSinceLastExposure: number;
+  lastExposureTimestamp: number;
   matchedKeyCount: number;
   maximumRiskScore: number;
 }

--- a/src/bridge/ExposureNotification/utils.ts
+++ b/src/bridge/ExposureNotification/utils.ts
@@ -1,0 +1,13 @@
+import {addDays, getCurrentDate} from 'shared/date-fns';
+
+import {ExposureSummary} from './types';
+
+/**
+ * TODO: remove in follow up PR https://github.com/cds-snc/covid-shield-mobile/issues/803
+ */
+export function getLastExposureTimestamp(summary: ExposureSummary) {
+  const today = getCurrentDate();
+  const lastExposureTimestamp =
+    summary.matchedKeyCount > 0 ? addDays(today, -summary.daysSinceLastExposure).getTime() : 0;
+  return lastExposureTimestamp;
+}

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -331,5 +331,73 @@ describe('ExposureNotificationService', () => {
         }),
       );
     });
+
+    it('keeps lastChecked when reset from exposed state to monitoring state', async () => {
+      const today = new OriginalDate('2020-05-18T04:10:00+0000');
+      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
+      const period = periodSinceEpoch(today, HOURS_PER_PERIOD);
+      service.exposureStatus.set({
+        type: 'exposed',
+        lastChecked: {
+          period,
+          timestamp: today.getTime(),
+        },
+        summary: {
+          daysSinceLastExposure: 2,
+          lastExposureTimestamp: today.getTime() - 14 * 3600 * 24 * 1000,
+          matchedKeyCount: 1,
+          maximumRiskScore: 1,
+        },
+      });
+
+      await service.updateExposureStatus();
+
+      expect(service.exposureStatus.get()).toStrictEqual(
+        expect.objectContaining({
+          lastChecked: {
+            period,
+            timestamp: today.getTime(),
+          },
+          type: 'monitoring',
+        }),
+      );
+    });
+
+    it('does not reset to monitoring state when lastExposureTimestamp is not available', async () => {
+      const today = new OriginalDate('2020-05-18T04:10:00+0000');
+      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
+      const period = periodSinceEpoch(today, HOURS_PER_PERIOD);
+      service.exposureStatus.set({
+        type: 'exposed',
+        lastChecked: {
+          period,
+          timestamp: today.getTime(),
+        },
+        summary: {
+          daysSinceLastExposure: 2,
+          lastExposureTimestamp: 0,
+          matchedKeyCount: 1,
+          maximumRiskScore: 1,
+        },
+      });
+
+      await service.updateExposureStatus();
+
+      expect(service.exposureStatus.get()).toStrictEqual(
+        expect.objectContaining({
+          type: 'exposed',
+          lastChecked: {
+            period,
+            timestamp: today.getTime(),
+          },
+          summary: {
+            daysSinceLastExposure: 2,
+            lastExposureTimestamp: 0,
+            matchedKeyCount: 1,
+            maximumRiskScore: 1,
+          },
+        }),
+      );
+    });
   });
 });

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -340,12 +340,13 @@ export class ExposureNotificationService {
         return finalize();
       }
       return finalize({needsSubmission: await this.calculateNeedsSubmission()});
-    } else if (
-      currentStatus.type === 'exposed' &&
-      currentStatus.summary.daysSinceLastExposure >= EXPOSURE_NOTIFICATION_CYCLE
-    ) {
-      this.exposureStatus.set({type: 'monitoring', lastChecked: currentStatus.lastChecked});
-      return finalize();
+    } else if (currentStatus.type === 'exposed') {
+      const today = getCurrentDate();
+      const lastExposureAt = new Date(currentStatus.summary.lastExposureTimestamp || today.getTime());
+      if (daysBetween(lastExposureAt, today) >= EXPOSURE_NOTIFICATION_CYCLE) {
+        this.exposureStatus.set({type: 'monitoring', lastChecked: currentStatus.lastChecked});
+        return finalize();
+      }
     }
 
     const keysFileUrls: string[] = [];

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -404,12 +404,12 @@ export class ExposureNotificationService {
     });
   }
 
-  private selectExposureSummary(summary: ExposureSummary): ExposureSummary {
+  private selectExposureSummary(nextSummary: ExposureSummary): ExposureSummary {
     const exposureStatus = this.exposureStatus.get();
     const currentSummary = exposureStatus.type === 'exposed' ? exposureStatus.summary : undefined;
-    return currentSummary && currentSummary.daysSinceLastExposure < summary.daysSinceLastExposure
-      ? currentSummary
-      : summary;
+    const currentLastExposureTimestamp = currentSummary?.lastExposureTimestamp || 0;
+    const nextLastExposureTimestamp = nextSummary.lastExposureTimestamp || 0;
+    return !currentSummary || nextLastExposureTimestamp > currentLastExposureTimestamp ? nextSummary : currentSummary;
   }
 
   private async processNotification() {

--- a/src/testMode/MockExposureNotification.ts
+++ b/src/testMode/MockExposureNotification.ts
@@ -4,6 +4,7 @@ export class MockExposureNotification implements ExposureNotification {
   private status: Status = Status.Active;
   private exposureSummary: ExposureSummary = {
     daysSinceLastExposure: 0,
+    lastExposureTimestamp: 0,
     matchedKeyCount: 0,
     maximumRiskScore: 0,
   };

--- a/src/testMode/TestMode.tsx
+++ b/src/testMode/TestMode.tsx
@@ -12,7 +12,6 @@ import {
 import {useStorage} from 'services/StorageService';
 import {ExposureSummary} from 'bridge/ExposureNotification';
 import {captureMessage} from 'shared/log';
-import {getCurrentDate} from 'shared/date-fns';
 
 import {MockProvider, useMock} from './MockProvider';
 import {Item} from './views/Item';
@@ -51,7 +50,8 @@ const DrawerContent = () => {
       case 'monitoring':
         // Change to exposed
         newExposureSummary = {
-          daysSinceLastExposure: getCurrentDate().getTime(),
+          daysSinceLastExposure: 0,
+          lastExposureTimestamp: 0,
           matchedKeyCount: 1,
           maximumRiskScore: 8,
         };
@@ -60,6 +60,7 @@ const DrawerContent = () => {
         // Change to monitoring
         newExposureSummary = {
           daysSinceLastExposure: 0,
+          lastExposureTimestamp: 0,
           matchedKeyCount: 0,
           maximumRiskScore: 0,
         };


### PR DESCRIPTION
This PR prioritize exposure summary that has larger `lastExposureTimestamp`. See more detail in the issue.

Resolves https://github.com/cds-snc/covid-shield-mobile/issues/803