### PR TITLE
Remove `RNSplashScreen` requirement in iOS.

### DIFF
--- a/ios/CovidShield/AppDelegate.m
+++ b/ios/CovidShield/AppDelegate.m
@@ -89,11 +89,17 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
-
+  
+  if([[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground) {
+    UIStoryboard *launchScreenStoryboard = [UIStoryboard storyboardWithName:@"Launch Screen" bundle:nil];
+    UIViewController *launchScreenController = [launchScreenStoryboard instantiateInitialViewController];
+    UIView *launchScreenView = [launchScreenController view];
+    launchScreenView.frame = self.window.bounds;
+    rootView.loadingView = launchScreenView;
+  }
 
   // [REQUIRED] Register BackgroundFetch
   [[TSBackgroundFetch sharedInstance] didFinishLaunching];
-  [RNSplashScreen show];
 
   // Define UNUserNotificationCenter
   UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];


### PR DESCRIPTION
Remove `RNSplashScreen` requirement, in favour of a more native approach.

It is hoped that the this will stop the Watchdog crashes in iOS that were reported. (See linked issue for details).

This approach is suggested here:
https://reactnative.dev/docs/running-on-device#pro-tips

It allows a splash screen to stay on the screen while the app initializes, without the potentially thread blocking code that causes Watchdog to trigger a crash. Also, checking the app state will prevent the splashscreen from showing up if the app is running in the background state.