### PR TITLE
Fix screenreader focus issues on page change by switching to old navigator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import Reactotron from 'reactotron-react-native';
 import {NativeModules, StatusBar} from 'react-native';
 import SplashScreen from 'react-native-splash-screen';
 import {DemoMode} from 'testMode';
-import {TEST_MODE, SUBMIT_URL, RETRIEVE_URL, HMAC_KEY} from 'env';
+import {SUBMIT_URL, RETRIEVE_URL, HMAC_KEY} from 'env';
 import {ExposureNotificationServiceProvider} from 'services/ExposureNotificationService';
 import {BackendService} from 'services/BackendService';
 import {I18nProvider} from 'locale';
@@ -53,13 +53,9 @@ const App = () => {
       <ExposureNotificationServiceProvider backendInterface={backendService}>
         <DevPersistedNavigationContainer persistKey="navigationState">
           <AccessibilityServiceProvider>
-            {TEST_MODE ? (
-              <DemoMode>
-                <MainNavigator />
-              </DemoMode>
-            ) : (
+            <DemoMode>
               <MainNavigator />
-            )}
+            </DemoMode>
           </AccessibilityServiceProvider>
         </DevPersistedNavigationContainer>
       </ExposureNotificationServiceProvider>

--- a/src/testMode/DemoMode.tsx
+++ b/src/testMode/DemoMode.tsx
@@ -10,6 +10,7 @@ import {
   useReportDiagnosis,
 } from 'services/ExposureNotificationService';
 import {captureMessage} from 'shared/log';
+import {TEST_MODE} from 'env';
 
 import {RadioButton} from './components/RadioButtons';
 import {MockProvider} from './MockProvider';
@@ -162,10 +163,11 @@ export const DemoMode = ({children}: DemoModeProps) => {
     return Component;
   }, [children]);
 
+  // disable the drawer if TEST_MODE === false
   return (
     <MockProvider>
       <Drawer.Navigator drawerPosition="right" drawerContent={drawerContent}>
-        <Drawer.Screen name="main" component={Component} />
+        <Drawer.Screen name="main" component={Component} options={TEST_MODE ? {} : {gestureEnabled: false}} />
       </Drawer.Navigator>
     </MockProvider>
   );


### PR DESCRIPTION
Closes #799, closes #801

Switch to the old navigator, keep the same nav nesting if `TEST_MODE === false`, just disable the gesture that opens the drawer in that case. Still needs testing on Android to make sure this will not re-introduce #755.