### PR TITLE
Fix issue cannot read property matchedKeyCount of null in getPendingExposureSummary

### DIFF
--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
@@ -27,7 +27,9 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: any
     },
     getPendingExposureSummary: async () => {
       const summary = await exposureNotificationAPI.getPendingExposureSummary();
-      summary.lastExposureTimestamp = getLastExposureTimestamp(summary);
+      if (summary) {
+        summary.lastExposureTimestamp = getLastExposureTimestamp(summary);
+      }
       return summary;
     },
   };


### PR DESCRIPTION
## What?

Bug was introduced since this PR https://github.com/cds-snc/covid-shield-mobile/pull/811

```
[Wed Jul 22 2020 08:51:30.383]  LOG      runPeriodicTask {"taskId": "app.covidshield.exposure-notification"}
[Wed Jul 22 2020 08:51:30.389]  LOG      updateExposureStatusInBackground {"exposureStatus": {"type": "monitoring"}}
[Wed Jul 22 2020 08:51:30.389]  LOG      Error: updateExposureStatusInBackground {"error": {"error": [TypeError: Cannot read property 'matchedKeyCount' of null], "message": "Cannot read property 'matchedKeyCount' of null"}}
```

## Impact

The app won't be able to check for exposure on Android.

