### PR TITLE
Fix accessibility

### DIFF
--- a/src/components/InfoBlock.tsx
+++ b/src/components/InfoBlock.tsx
@@ -33,7 +33,7 @@ export const InfoBlock = ({
   showButton,
   focusOnTitle,
 }: InfoBlockProps) => {
-  const [, autoFocusRef] = useAccessibilityAutoFocus(focusOnTitle);
+  const autoFocusRef = useAccessibilityAutoFocus(focusOnTitle);
   return (
     <Box borderRadius={10} backgroundColor={backgroundColor} padding="m" alignItems="flex-start">
       {icon && (

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -13,7 +13,7 @@ export type TextProps = RestyleTextProps<Theme> &
 
 export const Text = ({accessibilityAutoFocus = false, focusRef, ...props}: TextProps) => {
   const styledProps = useRestyle(textRestyleFunctions, props);
-  const [, autoFocusRef] = useAccessibilityAutoFocus(accessibilityAutoFocus);
+  const autoFocusRef = useAccessibilityAutoFocus(accessibilityAutoFocus);
   return <RNText accessible ref={focusRef ? focusRef : autoFocusRef} {...styledProps} />;
 };
 

--- a/src/screens/home/components/AllSetView.tsx
+++ b/src/screens/home/components/AllSetView.tsx
@@ -13,7 +13,7 @@ export const AllSetView = ({
   titleText: string;
   bodyText: string;
 }) => {
-  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
   return (
     <BaseHomeView iconName="thumbs-up">
       <Text focusRef={autoFocusRef} variant="bodyTitle" color="bodyText" marginBottom="m" accessibilityRole="header">

--- a/src/screens/home/views/DiagnosedShareView.tsx
+++ b/src/screens/home/views/DiagnosedShareView.tsx
@@ -10,7 +10,7 @@ export const DiagnosedShareView = ({isBottomSheetExpanded}: {isBottomSheetExpand
   const i18n = useI18n();
   const navigation = useNavigation();
   const toDataShare = useCallback(() => navigation.navigate('DataSharing'), [navigation]);
-  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
   return (
     <BaseHomeView iconName="hand-reminder">

--- a/src/screens/home/views/DiagnosedView.tsx
+++ b/src/screens/home/views/DiagnosedView.tsx
@@ -14,7 +14,7 @@ export const DiagnosedView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: b
   const i18n = useI18n();
   const {region} = useStorage();
   const [exposureStatus] = useExposureStatus();
-  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
   if (exposureStatus.type !== 'diagnosed') return null;
 

--- a/src/screens/home/views/ExposureNotificationsDisabledView.tsx
+++ b/src/screens/home/views/ExposureNotificationsDisabledView.tsx
@@ -25,7 +25,7 @@ export const ExposureNotificationsDisabledView = ({isBottomSheetExpanded}: {isBo
     }
     return toSettings();
   };
-  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
   return (
     <BaseHomeView iconName="icon-bluetooth-disabled">
       <Text focusRef={autoFocusRef} variant="bodyTitle" color="bodyText" marginBottom="m" accessibilityRole="header">

--- a/src/screens/home/views/ExposureView.tsx
+++ b/src/screens/home/views/ExposureView.tsx
@@ -30,7 +30,7 @@ export const ExposureView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: bo
     Linking.openURL(getGuidanceURL()).catch(err => console.error('An error occurred', err));
   }, [getGuidanceURL]);
   const onHowToIsolate = useCallback(() => navigation.navigate('HowToIsolate'), [navigation]);
-  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
   const isRegionOntario = region === 'ON';
 
   const getRegionForText = useCallback(() => {

--- a/src/screens/home/views/NoExposureCoveredRegionView.tsx
+++ b/src/screens/home/views/NoExposureCoveredRegionView.tsx
@@ -11,7 +11,7 @@ import {BaseHomeView} from '../components/BaseHomeView';
 export const NoExposureCoveredRegionView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: boolean}) => {
   const i18n = useI18n();
   const {onboardedDatetime, skipAllSet} = useStorage();
-  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
   if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
     return (

--- a/src/screens/home/views/NoExposureNoRegionView.tsx
+++ b/src/screens/home/views/NoExposureNoRegionView.tsx
@@ -12,7 +12,7 @@ export const NoExposureNoRegionView = ({isBottomSheetExpanded}: {isBottomSheetEx
   const i18n = useI18n();
   const {onboardedDatetime, skipAllSet} = useStorage();
 
-  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
   if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
     return (

--- a/src/screens/home/views/NoExposureUncoveredRegionView.tsx
+++ b/src/screens/home/views/NoExposureUncoveredRegionView.tsx
@@ -11,7 +11,7 @@ import {AllSetView} from '../components/AllSetView';
 export const NoExposureUncoveredRegionView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: boolean}) => {
   const i18n = useI18n();
   const {onboardedDatetime, skipAllSet} = useStorage();
-  const [, autoFocusRef] = useAccessibilityAutoFocus(!isBottomSheetExpanded);
+  const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
   if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
     return (

--- a/src/screens/nocode/NoCode.tsx
+++ b/src/screens/nocode/NoCode.tsx
@@ -2,13 +2,13 @@ import React, {useCallback} from 'react';
 import {ScrollView, StyleSheet, Linking} from 'react-native';
 import {Box, Text, TextMultiline, Toolbar, ButtonSingleLine} from 'components';
 import {useI18n} from 'locale';
-import {useNavigation, useFocusEffect} from '@react-navigation/native';
+import {useNavigation} from '@react-navigation/native';
 import {useStorage} from 'services/StorageService';
 import {getRegionCase} from 'shared/RegionLogic';
 import {BulletPoint} from 'components/BulletPoint';
 import {BulletPointOrdered} from 'components/BulletPointOrdered';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {useAccessibilityAutoFocus, focusOnElement} from 'shared/useAccessibilityAutoFocus';
+import {useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
 
 interface ContentProps {
   title: string;
@@ -20,10 +20,7 @@ interface ContentProps {
 }
 
 const Content = ({title, body, notCoveredList, coveredList, externalLinkText, externalLinkCTA}: ContentProps) => {
-  const [focusRef, autoFocusRef] = useAccessibilityAutoFocus(true);
-  useFocusEffect(() => {
-    focusOnElement(focusRef);
-  });
+  const autoFocusRef = useAccessibilityAutoFocus(true);
   const externalLinkButton =
     externalLinkCTA && externalLinkText ? (
       <ButtonSingleLine

--- a/src/screens/onboarding/views/ItemView.tsx
+++ b/src/screens/onboarding/views/ItemView.tsx
@@ -2,8 +2,7 @@ import React, {ReactNode} from 'react';
 import {StyleSheet, Image, ImageSourcePropType} from 'react-native';
 import {Box, Text} from 'components';
 import {useI18n} from 'locale';
-import {focusOnElement, useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
-import {useFocusEffect} from '@react-navigation/native';
+import {useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
 
 import {onboardingData, OnboardingKey} from '../OnboardingContent';
 
@@ -18,16 +17,13 @@ export interface ItemViewProps {
 
 export const ItemView = ({item, image, isActive, altText, header, children}: ItemViewProps) => {
   const i18n = useI18n();
-  const [focusRef, autoFocusRef] = useAccessibilityAutoFocus(isActive);
+  const autoFocusRef = useAccessibilityAutoFocus(isActive);
   const total = onboardingData.length;
   const step = i18n.translate('Onboarding.Step');
   const of = i18n.translate('Onboarding.Of');
   const x = onboardingData.indexOf(item) + 1;
   const stepText = `${step} ${x} ${of} ${total}`;
 
-  useFocusEffect(() => {
-    focusOnElement(focusRef);
-  });
   return (
     <>
       <Text focusRef={autoFocusRef} marginBottom="s" marginTop="s" color="gray2">

--- a/src/screens/tutorial/views/ItemView.tsx
+++ b/src/screens/tutorial/views/ItemView.tsx
@@ -14,7 +14,7 @@ export interface ItemViewProps {
 
 export const ItemView = ({item, image, isActive}: ItemViewProps) => {
   const i18n = useI18n();
-  const [, autoFocusRef] = useAccessibilityAutoFocus(isActive);
+  const autoFocusRef = useAccessibilityAutoFocus(isActive);
 
   return (
     <>

--- a/src/shared/useAccessibilityAutoFocus.ts
+++ b/src/shared/useAccessibilityAutoFocus.ts
@@ -22,7 +22,7 @@ const focusOnElement = (elementRef: any) => {
  * @returns [Manual focus ref , Auto focus ref]
  */
 export const useAccessibilityAutoFocus = (isActive = true) => {
-  const [autoFocusRef, setAutoFocusRef] = useState<React.LegacyRef<any>>();
+  const [autoFocusRef, setAutoFocusRef] = useState<any>();
 
   const {isScreenReaderEnabled} = useAccessibilityService();
   const [isFocus, setIsFocus] = useState(false);

--- a/src/shared/useAccessibilityAutoFocus.ts
+++ b/src/shared/useAccessibilityAutoFocus.ts
@@ -1,7 +1,7 @@
-import {useLayoutEffect, useMemo, useState} from 'react';
+import {useLayoutEffect, useState, useCallback} from 'react';
 import {AccessibilityInfo, findNodeHandle} from 'react-native';
-
-import {createCancellableCallbackPromise} from './cancellablePromise';
+import {useFocusEffect} from '@react-navigation/native';
+import {useAccessibilityService} from 'services/AccessibilityService';
 
 /**
  * Look like there is timing issue with AccessibilityInfo.setAccessibilityFocus
@@ -9,7 +9,7 @@ import {createCancellableCallbackPromise} from './cancellablePromise';
  */
 const AUTO_FOCUS_DELAY = 500;
 
-export const focusOnElement = (elementRef: any) => {
+const focusOnElement = (elementRef: any) => {
   const node = findNodeHandle(elementRef);
   if (!node) {
     return;
@@ -22,36 +22,44 @@ export const focusOnElement = (elementRef: any) => {
  * @returns [Manual focus ref , Auto focus ref]
  */
 export const useAccessibilityAutoFocus = (isActive = true) => {
-  const [autoFocusRef, setAutoFocusRef] = useState<any>();
+  const [autoFocusRef, setAutoFocusRef] = useState<React.LegacyRef<any>>();
 
-  const {callable, cancelable} = useMemo(() => {
-    return createCancellableCallbackPromise(
-      () => AccessibilityInfo.isScreenReaderEnabled().then(delay(AUTO_FOCUS_DELAY)),
-      isScreenReaderEnabled => {
-        if (!isScreenReaderEnabled) {
-          return;
-        }
-        focusOnElement(autoFocusRef);
-      },
-    );
-  }, [autoFocusRef]);
+  const {isScreenReaderEnabled} = useAccessibilityService();
+  const [isFocus, setIsFocus] = useState(false);
+  const [isLayoutUpdated, setIsLayoutUpdated] = useState(false);
 
   useLayoutEffect(() => {
-    if (!autoFocusRef || !isActive) {
+    setIsLayoutUpdated(true);
+    return () => {
+      setIsLayoutUpdated(false);
+    };
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      setIsFocus(true);
+      return () => {
+        setIsFocus(false);
+      };
+    }, []),
+  );
+
+  useLayoutEffect(() => {
+    if (!isScreenReaderEnabled || !isActive || !isFocus || !isLayoutUpdated || !autoFocusRef) {
       return;
     }
 
-    callable();
-    return cancelable;
-  }, [callable, cancelable, autoFocusRef, isActive]);
+    // Call focus as soon as all considition is met
+    focusOnElement(autoFocusRef);
 
-  return [autoFocusRef, setAutoFocusRef];
+    // Attempt to call it again just in case AccessibilityInfo.setAccessibilityFocus is delayed
+    const timeoutId = setTimeout(() => {
+      focusOnElement(autoFocusRef);
+    }, AUTO_FOCUS_DELAY);
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [autoFocusRef, isActive, isFocus, isLayoutUpdated, isScreenReaderEnabled]);
+
+  return setAutoFocusRef;
 };
-
-function delay<T>(timeout: number) {
-  return (value: T) => {
-    return new Promise<T>(function(resolve) {
-      setTimeout(resolve.bind(null, value), timeout);
-    });
-  };
-}

--- a/src/testMode/DemoMode.tsx
+++ b/src/testMode/DemoMode.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useMemo} from 'react';
 import {createDrawerNavigator, DrawerContentScrollView} from '@react-navigation/drawer';
+import {createStackNavigator} from '@react-navigation/stack';
 import {useI18n} from 'locale';
 import PushNotification from 'bridge/PushNotification';
 import {Box, Button, LanguageToggle, Text} from 'components';
@@ -149,6 +150,8 @@ const DrawerContent = () => {
   );
 };
 
+const DemoStack = createStackNavigator();
+
 export interface DemoModeProps {
   children?: React.ReactElement;
 }
@@ -162,11 +165,19 @@ export const DemoMode = ({children}: DemoModeProps) => {
     return Component;
   }, [children]);
 
-  return (
-    <MockProvider>
+  const Screen = useCallback(() => {
+    return (
       <Drawer.Navigator drawerPosition="right" drawerContent={drawerContent}>
         <Drawer.Screen name="main" component={Component} />
       </Drawer.Navigator>
+    );
+  }, [Component, drawerContent]);
+
+  return (
+    <MockProvider>
+      <DemoStack.Navigator screenOptions={{headerShown: false}} initialRouteName="Demo">
+        <DemoStack.Screen name="Demo" component={Screen} />
+      </DemoStack.Navigator>
     </MockProvider>
   );
 };


### PR DESCRIPTION
This PR attempts to fix accessibility issue in onboarding flow and navigation between screen. 

## Test cases
- ✅ Fresh start app with language already selected -> it should read out 'Step 1 of 6' on the onboarding screen
- ✅ Go to Step 3 and select 'Learn more about how it works' then close the window after it opens -> it should read out the title again `Step 3 of 6`.
- ✅ Open bottom sheet -> it should read 'Diagnosed with COVID-19?' 
- ✅ Go to code enter screen and select 'Need a one-time key?'  -> it should read 'Let people know they may have been exposed' .
- ✅ Press cancel from `Need a one-time key` screen -> back to bottom sheet -> it should read 'Diagnosed with COVID-19?'.

Ref 
- https://github.com/cds-snc/covid-shield-mobile/issues/689
- https://github.com/cds-snc/covid-shield-mobile/pull/825
