### PR TITLE
Fix notification channel naming

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/PushNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/PushNotificationModule.kt
@@ -23,9 +23,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
-private const val CHANNEL_ID = "CovidShield"
-private const val CHANNEL_NAME = "CovidShield"
-private const val CHANNEL_DESC = "CovidShield"
+private const val CHANNEL_ID = "COVID Alert"
+private const val CHANNEL_NAME = "COVID Alert"
+private const val CHANNEL_DESC = "COVID Alert"
 
 /**
  * See https://developer.android.com/training/notify-user/build-notification#kotlin


### PR DESCRIPTION
This PR fixes notification channel naming.

Ref https://github.com/cds-snc/covid-shield-mobile/issues/836