### PR TITLE
Fix potential null dereference in iOS code

### DIFF
--- a/ios/CovidShield/CovidShield.m
+++ b/ios/CovidShield/CovidShield.m
@@ -13,16 +13,17 @@ RCT_EXPORT_MODULE();
 
 RCT_REMAP_METHOD(getRandomBytes, randomBytesWithSize:(NSUInteger)size withResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
+  int status = errSecSuccess;
   void *buff = malloc(size);
-  int status = SecRandomCopyBytes(kSecRandomDefault, size, buff);
-  if (status == errSecSuccess) {
+  
+  if (buff && ((status = SecRandomCopyBytes(kSecRandomDefault, size, buff)) == errSecSuccess)) {
     NSString *base64encoded = [[[NSData alloc] initWithBytes:buff length:size] base64EncodedStringWithOptions:0];
     resolve(base64encoded);
   } else {
     NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:status userInfo:nil];
     reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription ,error);
   }
-  free(buff);
+  if(buff) free(buff);
 }
 
 RCT_REMAP_METHOD(downloadDiagnosisKeysFile, downloadDiagnosisKeysFileWithURL:(NSString *)url WithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
To fix #789 . On contrary to the original comment this uses low-level API, as NSMutableData could also fail returning nil, so it wouldn't rather save a lot of lines.