### PR TITLE
Fix bug where iOS system status was not updating quickly enough

### DIFF
--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -131,6 +131,10 @@ export class ExposureNotificationService {
       await this.exposureNotification.start();
     } catch (error) {
       captureException('Cannot start EN framework', error);
+      if (error.message === 'ENErrorCodeNotAuthorized (User denied)') {
+        this.systemStatus.set(SystemStatus.Disabled);
+        return;
+      }
       this.systemStatus.set(SystemStatus.Unknown);
       return;
     }

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -131,17 +131,11 @@ export class ExposureNotificationService {
       await this.exposureNotification.start();
     } catch (error) {
       captureException('Cannot start EN framework', error);
-      // 4: 'ENErrorCodeNotAuthorized (User denied)'
-      // https://developer.apple.com/documentation/exposurenotification/enerrorcode/enerrorcodenotauthorized?language=objc
-      if (error.code === '4') {
-        this.systemStatus.set(SystemStatus.Disabled);
-        return;
-      }
       this.systemStatus.set(SystemStatus.Unknown);
-      return;
     }
 
     await this.updateSystemStatus();
+    console.log('this.systemStatus.get()', this.systemStatus.get());
     this.starting = false;
     await this.updateExposureStatus();
   }

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -135,7 +135,6 @@ export class ExposureNotificationService {
     }
 
     await this.updateSystemStatus();
-    console.log('this.systemStatus.get()', this.systemStatus.get());
     this.starting = false;
     await this.updateExposureStatus();
   }

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -131,7 +131,9 @@ export class ExposureNotificationService {
       await this.exposureNotification.start();
     } catch (error) {
       captureException('Cannot start EN framework', error);
-      if (error.message === 'ENErrorCodeNotAuthorized (User denied)') {
+      // 4: 'ENErrorCodeNotAuthorized (User denied)'
+      // https://developer.apple.com/documentation/exposurenotification/enerrorcode/enerrorcodenotauthorized?language=objc
+      if (error.code === '4') {
         this.systemStatus.set(SystemStatus.Disabled);
         return;
       }


### PR DESCRIPTION
Closes #861 (Part of #857)

Added logic to set systemStatus to disabled if we have an iOS error indicating the user has disabled the framework. I am just checking against a string right now but I know this is not the correct way to check the type of error. @henrytao-me do you know how to do that properly?

<img width="554" alt="Screen Shot 2020-07-23 at 11 11 47 AM" src="https://user-images.githubusercontent.com/35537308/88309923-0a3f9800-ccdd-11ea-9578-25c4fb62e919.png">
