### PR TITLE
minor text change in onboarding

### DIFF
--- a/src/locale/translations/en.json
+++ b/src/locale/translations/en.json
@@ -201,7 +201,7 @@
     "Anonymous": {
       "Title": "Your privacy is protected",
       "ImageAltText": "A hand-drawn illustration of shaded glasses and hat to go incognito. Above the hat, a location pin icon is crossed out.",
-      "Body1": "COVID Alert **does not use GPS** or location services.",
+      "Body1": "COVID Alert **does not use GPS** or track your location.",
       "Body2": "It has **no way of knowing**:",
       "Bullet1": "Your location.",
       "Bullet2": "Your name or address.",
@@ -214,7 +214,7 @@
       "ImageAltText": "A hand-drawn illustration of 3 mobile phones sending out random codes via bluetooth.",
       "Body1": "The app uses Bluetooth to exchange random codes with nearby phones.",
       "Body2": "Every day, it checks a list of random codes from people who tell the app they tested positive.",
-      "Body3": "If you’ve  had close contact with one of those people in the past 14 days, you’ll get a notification.",
+      "Body3": "If you’ve had close contact with one of those people in the past 14 days, you’ll get a notification.",
       "HowItWorksCTA": "Learn more about how it works"
     },
     "PartOf": {


### PR DESCRIPTION
Changed "does not use location services" to "does not track your location" to use more human language. Removed an extra space from How it works screen in onboarding (part of issue #857)
Tagging @EliseKa 