### PR TITLE
minor FR edits

### DIFF
--- a/src/assets/privacypolicy-fr.js
+++ b/src/assets/privacypolicy-fr.js
@@ -24,7 +24,7 @@ Les codes aléatoires sont stockés et utilisés uniquement dans le but de vous 
 
 ## Si vous avez un téléphone Android
 
-- Avec les téléphones Android, la recherche Bluetooth n’est possible que si la fonction de localisation est activée pour toutes les applications. Bien qu’Alerte COVID n’ait aucun moyen de connaître votre emplacement, Google peut avoir accès à votre position. Si vous avez un téléphone Android, vous voudrez peut-être utiliser l’option de localisation la moins précise et désactiver l’historique des positions.
+- Avec les téléphones Android, la recherche Bluetooth n’est possible que si la fonction de localisation est activée pour toutes les applications. Bien qu’Alerte COVID n’ait aucun moyen de connaître votre emplacement, Google peut avoir accès à votre position. Si vous avez un téléphone Android, vous pourriez envisager d’utiliser l’option de localisation la moins précise et de désactiver l’historique des positions.
 - Vous pouvez vérifier les autorisations des applications dans les paramètres de votre téléphone. Vous constaterez qu’Alerte COVID n’a pas l’autorisation d’utiliser les services de localisation.
 
 
@@ -34,7 +34,7 @@ Les codes aléatoires sont stockés et utilisés uniquement dans le but de vous 
 - Quand vous donnez votre autorisation, seuls les codes aléatoires de votre téléphone sont partagés.
 - Seuls l’application et son serveur auront accès aux codes aléatoires.
 
-### Si vous avez un diagnostic de COVID-19
+### Si vous recevez un diagnostic de COVID-19
 - Vous pouvez décider de partager vos codes aléatoires des 14 derniers jours avec un serveur central administré par le Gouvernement du Canada.
 - Si vous partagez vos codes, personne ne recevra d’information sur vous ou sur le moment de votre proximité.
 - On vous demandera aussi l’autorisation de partager vos codes aléatoires avec le serveur central pendant les 13 jours qui suivent.
@@ -77,7 +77,8 @@ Sans ces protections de sécurité en place, les polluposteurs pourraient inonde
 Contactez la ligne d’information sur la COVID-19 :
 - Téléphone : 1-833-784-4397
 - Téléscripteur (ATS) : 1-800-465-7735
-  (Du lundi au vendredi, de 8 h à 20 h, heure de l’Est.)
+  Du lundi au vendredi, de 8 h à 20 h (heure de l’Est)
+- Courriel : hc.AlerteCOVIDAlert.sc@canada.ca
 `;
 
 export default privacy;

--- a/src/locale/translations/fr.json
+++ b/src/locale/translations/fr.json
@@ -41,7 +41,7 @@
       "Body1": "Votre téléphone vous demandera l’autorisation de téléverser vos codes ou « identifiants » aléatoires des 14 derniers jours.",
       "Body2a": "Personne ne recevra d’information sur vous ",
       "Body2b": "ou sur le moment de votre proximité.",
-      "Body3": "Vous pouvez aider à ralentir la propagation de COVID-19 si vous acceptez.",
+      "Body3": "Vous pouvez aider à ralentir la propagation de la COVID-19 si vous acceptez.",
       "Action": "Accepter",
       "ErrorTitle": "Les codes aléatoires n’ont pas pu être téléversés",
       "ErrorBody": "Vous n’avez pas donné votre autorisation.",
@@ -206,7 +206,7 @@
     "Title": "Langue"
   },
   "Notification": {
-    "DailyUploadNotificationBody": "Aidez à ralentir la propagation de COVID-19 en téléversant vos nouveaux codes aléatoires.",
+    "DailyUploadNotificationBody": "Aidez à ralentir la propagation de la COVID-19 en téléversant vos nouveaux codes aléatoires.",
     "DailyUploadNotificationTitle": "Téléversez vos nouveaux codes aléatoires",
     "ExposedMessageBody": "Vous avez eu un contact étroit avec une personne qui a signalé un diagnostic de COVID-19 au moyen de l’application. Informez-vous sur les étapes à suivre.",
     "ExposedMessageTitle": "Vous avez été exposé",
@@ -221,7 +221,7 @@
     "ActionNext": "Suivant",
     "ActionEndSkip": "Ignorer",
     "Start": {
-      "Title": "Unissons-nous pour freiner la propagation de COVID-19",
+      "Title": "Unissons-nous pour freiner la propagation de la COVID-19",
       "ImageAltText": "Dessin à la main avec plusieurs personnes différentes dedans. Leurs chemins en lignes pointillées se croisent et mènent à un téléphone intelligent plus bas.",
       "Body1": "Alerte COVID nous aide à briser le cycle d’infection. L’application permet d’aviser les personnes en cas d’exposition potentielle avant même que des symptômes apparaissent. ",
       "Body2": "Nous pouvons ainsi prendre soin de nous et protéger nos communautés."
@@ -235,7 +235,7 @@
     "Anonymous": {
       "Title": "Votre vie privée est protégée",
       "ImageAltText": "Dessin à la main d’une paire de lunettes de soleil et d’un chapeau pour passer incognito. Au-dessus du chapeau, une icône de marqueur de géolocalisation est biffée.",
-      "Body1": "Alerte COVID **n’utilise pas le GPS** ou les services de localisation.",
+      "Body1": "Alerte COVID **n’utilise pas le GPS** et ne suit pas votre emplacement.",
       "Body2": "L’application **n’a aucun moyen** de connaître\u00A0:",
       "Bullet1": "Votre emplacement.",
       "Bullet2": "Votre nom ou votre adresse.",
@@ -254,7 +254,7 @@
     "PartOf": {
       "Title": "L’un des efforts de santé publique",
       "ImageAltText": "Dessin à la main de divers moyens de lutter contre la COVID-19, dont un désinfectant pour les mains, un couvre-visage, des mains avec du savon et l’application Alerte COIVID.",
-      "Body1": "Alerte COVID n’est qu’une partie des efforts de santé publique visant à freiner la propagation de COVID-19.",
+      "Body1": "Alerte COVID n’est qu’une partie des efforts de santé publique visant à freiner la propagation de la COVID-19.",
       "Body2": "Continuez à suivre les recommandations de santé publique de votre région.",
       "Body3": "Alerte COVID ne remplace pas un avis médical. Si vous tombez malade, contactez votre médecin ou un professionnel de la santé."
     },
@@ -279,7 +279,7 @@
     "BluetoothCardBody": "Vous devez l’activer dans les paramètres de votre téléphone pour qu’Alerte COVID fonctionne.",
     "EnterCodeCardAction": "Entrer votre clé",
     "EnterCodeCardBody": "Vous avez besoin d’une clé à usage unique pour aviser les autres personnes d’une exposition.",
-    "EnterCodeCardBodyDiagnosed": "Merci de faire votre part pour freiner la propagation de COVID-19. ",
+    "EnterCodeCardBodyDiagnosed": "Merci de faire votre part pour freiner la propagation de la COVID-19. ",
     "EnterCodeCardDiagnosedCountdown": {
       "One": "Il vous reste {number}\u00A0jour!",
       "Other": "Il vous reste {number}\u00A0jours!"
@@ -287,10 +287,10 @@
     "EnterCodeCardTitle": "Vous avez la COVID-19?",
     "EnterCodeCardTitleDiagnosed": "Vous contribuez à freiner la COVID",
     "ExposureNotificationCardAction": "Activez les notifications d'exposition",
-    "ExposureNotificationCardBody": "Alerte COVID ne peut pas vous aviser de la découverte d’une exposition potentielle. Le fait d’être notifié rapidement est essentiel pour ralentir la propagation de COVID-19.",
+    "ExposureNotificationCardBody": "Alerte COVID ne peut pas vous aviser de la découverte d’une exposition potentielle. Le fait d’être notifié rapidement est essentiel pour ralentir la propagation de la COVID-19.",
     "ExposureNotificationCardStatus": "Les notifications d’exposition à la COVID-19 sont ",
     "NotificationCardAction": "Activer les notifications",
-    "NotificationCardBody": "Alerte COVID ne peut pas vous aviser dès qu’il découvre une exposition potentielle. Le fait d’être notifié rapidement est essentiel pour ralentir la propagation de COVID-19.",
+    "NotificationCardBody": "Alerte COVID ne peut pas vous aviser dès qu’il découvre une exposition potentielle. Le fait d’être notifié rapidement est essentiel pour ralentir la propagation de la COVID-19.",
     "NotificationCardStatus": "Les notifications sont désactivées",
     "NotificationCardStatusOff": "DÉSACTIVÉES",
     "NoConnectivityCardAction": "Alerte COVID est hors ligne",


### PR DESCRIPTION
Ajout du déterminant « la » avant COVID (in onboarding, part of issue #856)
Changed "does not use location services" to "does not track your location"